### PR TITLE
Add Istanbul test coverage tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .*.swp
 docs/build/
 jsreport/
+coverage/

--- a/docs/source/dev/development.rst
+++ b/docs/source/dev/development.rst
@@ -76,6 +76,8 @@ tests and measure coverage, run::
 
 	npm run coverage
 
+To see a detailed coverage report, open ``coverage/lcov-report/index.html``.
+
 .. _Istanbul: https://github.com/gotwarlost/istanbul
 .. _`its documentation`: http://mochajs.org/
 
@@ -103,4 +105,3 @@ test suite and marks the push as working or not. This is especially helpful
 during code review.
 
 Travis runs the test suite and the linter as described above.
-

--- a/docs/source/dev/development.rst
+++ b/docs/source/dev/development.rst
@@ -71,6 +71,12 @@ TimeSync uses Mocha for testing. See `its documentation`_ for more information
 on how to write tests, or use the tests included in TimeSync as a guide. They
 can be found in ``tests/``.
 
+TimeSync test coverage is measured with the `Istanbul`_ package. To run the
+tests and measure coverage, run::
+
+	npm run coverage
+
+.. _Istanbul: https://github.com/gotwarlost/istanbul
 .. _`its documentation`: http://mochajs.org/
 
 Code standards

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "recreate": "rm dev.sqlite3 && knex migrate:latest",
     "linter": "jshint ./src ./tests && jscs ./src ./tests",
     "fixtures": "node ./scripts/load_fixtures.js",
-    "test": "export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && istanbul cover _mocha -- tests"
+    "test": "DATABASE=mocha PORT=8851 istanbul cover _mocha -- tests"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
     "migrations": "knex migrate:latest",
     "recreate": "rm dev.sqlite3 && knex migrate:latest",
     "linter": "jshint ./src ./tests && jscs ./src ./tests",
-    "coverage": "export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && istanbul cover _mocha -- tests",
     "fixtures": "node ./scripts/load_fixtures.js",
-    "test": "export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && mocha tests/"
+    "test": "export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && istanbul cover _mocha -- tests"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "recreate": "rm dev.sqlite3 && knex migrate:latest",
     "linter": "jshint ./src ./tests && jscs ./src ./tests",
     "fixtures": "node ./scripts/load_fixtures.js",
-    "test": "DATABASE=mocha PORT=8851 istanbul cover _mocha -- tests"
+    "test": "DATABASE=mocha PORT=8851 mocha tests",
+    "coverage": "DATABASE=mocha PORT=8851 istanbul cover _mocha -- tests"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "migrations": "knex migrate:latest",
     "recreate": "rm dev.sqlite3 && knex migrate:latest",
     "linter": "jshint ./src ./tests && jscs ./src ./tests",
+    "coverage": "export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && istanbul cover _mocha -- tests",
     "fixtures": "node ./scripts/load_fixtures.js",
     "test": "export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && mocha tests/"
   },
@@ -36,6 +37,7 @@
     "sqlite3": "^3.0.8"
   },
   "devDependencies": {
+    "istanbul": "^0.3.17",
     "jscs": "^1.13.1",
     "jshint": "^2.8.0",
     "request": "^2.55.0",

--- a/tests/test.js
+++ b/tests/test.js
@@ -14,6 +14,12 @@ var base_url = 'http://localhost:' + port + '/v1/';
 
 describe('Endpoints', function() {
 
+    before(function(done) {
+        knex.migrate.latest().then(function() {
+            done();
+        });
+    });
+
     beforeEach(function(done) {
         this.timeout(5000);
         // Clear SQLite indexes


### PR DESCRIPTION
![Istanbul skyline](http://photos.travellerspoint.com/403576/large_IMG_1769_tonemapped.jpg)

```
(timesync)iankronquist@puppettop:(timesync)(ian/istanbul-sokaklari) → npm run coverage

> timesync@0.0.0 coverage /Users/iankronquist/gg/timesync
> export DATABASE=mocha export PORT=8851 && rm -f test.sqlite3 && knex --env mocha migrate:latest && istanbul cover _mocha -- tests

Using environment: mocha
Batch 1 run: 1 migrations 
/Users/iankronquist/gg/timesync/migrations/20150101000000_00.js


App now listening on 8851
  Endpoints
    GET /times
      ✓ should return all times in the database
    GET /times/:id
      ✓ should return times by id
      ✓ should fail with Object not found error
    GET /users
      ✓ should return all users in the database
    GET /activities
      ✓ should return all activities in the database
    GET /activities/:slug
      ✓ should return activities by slug
      ✓ should fail with invalid slug error
    GET /projects
      ✓ should return all projects in the database
    GET /projects/:slug
      ✓ should return projects by slug
      ✓ should fail with invalid slug error


  10 passing (460ms)

=============================================================================
Writing coverage object [/Users/iankronquist/gg/timesync/coverage/coverage.json]
Writing coverage reports at [/Users/iankronquist/gg/timesync/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 89.22% ( 149/167 )
Branches     : 63.16% ( 24/38 )
Functions    : 79.07% ( 34/43 )
Lines        : 89.22% ( 149/167 )
================================================================================

```