### PR TITLE
Make tests actually check for equality

### DIFF
--- a/tests/activities.js
+++ b/tests/activities.js
@@ -28,7 +28,7 @@ module.exports = function(expect, request, base_url) {
                     });
                 });
 
-                expect(err === null);
+                expect(err).to.be(null);
                 expect(res.statusCode).to.be(200);
                 expect(json_body).to.eql(expected_results);
                 done();
@@ -49,7 +49,7 @@ module.exports = function(expect, request, base_url) {
                 expected_result.slugs.sort();
                 json_body.slugs.sort();
 
-                expect(err === null);
+                expect(err).to.be(null);
                 expect(res.statusCode).to.be(200);
 
                 expect(json_body).to.eql(expected_result);

--- a/tests/projects.js
+++ b/tests/projects.js
@@ -34,7 +34,7 @@ module.exports = function(expect, request, base_url) {
                     });
                 });
 
-                expect(err === null);
+                expect(err).to.be(null);
                 expect(res.statusCode).to.be(200);
 
                 expect(json_body).to.eql(expected_results);
@@ -58,7 +58,7 @@ module.exports = function(expect, request, base_url) {
                 expected_result.slugs.sort();
                 json_body.slugs.sort();
 
-                expect(err === null);
+                expect(err).to.be(null);
                 expect(res.statusCode).to.be(200);
 
                 expect(json_body).to.eql(expected_result);

--- a/tests/times.js
+++ b/tests/times.js
@@ -18,7 +18,7 @@ module.exports = function(expect, request, base_url) {
                         id: 1
                     }
                 ];
-                expect(err === null);
+                expect(err).to.be(null);
                 expect(res.statusCode).to.be(200);
                 expect(JSON.parse(bodyAsString)).to.eql(expected_results);
                 done();
@@ -50,7 +50,7 @@ module.exports = function(expect, request, base_url) {
                 json_body.project.sort();
                 json_body.activity.sort();
 
-                expect(err === null);
+                expect(err).to.be(null);
                 expect(res.statusCode).to.be(200);
 
                 expect(json_body).to.eql(expected_result);

--- a/tests/users.js
+++ b/tests/users.js
@@ -13,7 +13,7 @@ module.exports = function(expect, request, base_url) {
                         username: 'tschuy'
                     }
                 ];
-                expect(err === null);
+                expect(err).to.be(null);
                 expect(res.statusCode).to.be(200);
                 expect(JSON.parse(bodyAsString)).to.eql(expected_results);
                 done();


### PR DESCRIPTION
``expect(a === b)`` is meaningless. What we really want, in order to test that equality, is ``expect(a).to.be(b)``: https://github.com/Automattic/expect.js#api