### PR TITLE
Lint camel case identifiers with jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -43,6 +43,7 @@
     "requireDotNotation": true,
     "requireSpacesInForStatement": true,
     "requireSpaceBetweenArguments": true,
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
     "requireCurlyBraces": [
         "do"
     ],


### PR DESCRIPTION
Watch travis *fail*.  Too many pythonistas around.