### PR TITLE
Add latte command

### DIFF
--- a/docs/source/dev/development.rst
+++ b/docs/source/dev/development.rst
@@ -63,7 +63,13 @@ Some other commands have been made available through TimeSync's
 Testing
 -------
 
-To test the application, use the test command::
+TimeSync comes with a single command to run the tests, linters, and test
+coverage commands all at once. It's Latte, or *Lint and Throughly Test
+Everything*::
+
+    npm run latte
+
+To only test the application, use the test command::
 
     npm test
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "linter": "jshint ./src ./tests && jscs ./src ./tests",
     "fixtures": "node ./scripts/load_fixtures.js",
     "test": "DATABASE=mocha PORT=8851 mocha tests",
+    "latte": "sh ./scripts/latte.sh",
     "coverage": "DATABASE=mocha PORT=8851 istanbul cover _mocha -- tests"
   },
   "repository": {

--- a/scripts/latte.sh
+++ b/scripts/latte.sh
@@ -1,0 +1,3 @@
+npm run linter
+npm run coverage
+echo "See coverage/index.html for full coverage information."

--- a/scripts/latte.sh
+++ b/scripts/latte.sh
@@ -1,3 +1,3 @@
 npm run linter
 npm run coverage
-echo "See coverage/index.html for full coverage information."
+echo "See file://`pwd`/coverage/lcov-report/index.html for full coverage information."


### PR DESCRIPTION
It runs the linter and then the tests, before printing test coverage.

Is there a better order?