### PR TITLE
Add Grunt to automatically restart the server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,25 @@
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    watch: {
+      js: {
+        files: [
+          'src/*.js'
+        ],
+        tasks: ['develop'],
+        options: { nospawn: true }
+      }
+    },
+    develop: {
+      server: {
+        file: 'src/app.js'
+      }
+    }
+  });
+
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-develop');
+
+  grunt.registerTask('default', ['develop', 'watch']);
+
+};

--- a/docs/source/dev/development.rst
+++ b/docs/source/dev/development.rst
@@ -46,7 +46,15 @@ run the migrations::
 
     npm run migrations
 
-And run the server::
+TimeSync comes with a very basic Gruntfile that automatically restarts the
+server whenever files in ``src/`` are changed. To start Grunt, just run::
+
+    npm run grunt
+
+For more information on Grunt, see Grunt's `Getting Started guide`_.
+
+Alternatively, if you don't want to use Grunt, you can use Node's built-in
+runner::
 
     npm start
 
@@ -59,6 +67,9 @@ Some other commands have been made available through TimeSync's
     * ``npm run recreate``: destroy the database and re-run migrations
     * ``npm run linter``: run the jshint Javascript linter
     * ``npm run fixtures``: install a set of test fixtures
+
+.. _`Getting Started guide`: http://gruntjs.com/getting-started
+
 
 Testing
 -------

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "body-parser": "^1.12.3",
     "expect.js": "^0.3.1",
     "express": "^4.12.3",
+    "grunt": "^0.4.5",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-develop": "^0.4.0",
     "knex": "^0.8.6",
     "mocha": "^2.2.4",
     "sqlite3": "^3.0.8"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "node ./src/app.js",
     "migrations": "knex migrate:latest",
+    "grunt": "grunt",
     "recreate": "rm dev.sqlite3 && knex migrate:latest",
     "linter": "jshint ./src ./tests && jscs ./src ./tests",
     "fixtures": "node ./scripts/load_fixtures.js",


### PR DESCRIPTION
This can be really annoying -- you're debugging an endpoint with your favorite REST client, and you have to restart the server every. Time. Something. Is. Changed.

This adds Grunt, "the Javascript Task Runner", so that we can just run Grunt without running into restart issues.

Docs in /docs. tl;dr:

```
$ npm install
$ npm run grunt
```