### PR TITLE
rearrange before/after database hooks

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -49,11 +49,9 @@ describe('Endpoints', function() {
     });
 
     beforeEach(function(done) {
-        reloadFixtures(done);
-    });
-
-    afterEach(function(done) {
-        clearDatabase(done);
+        clearDatabase(function() {
+            reloadFixtures(done);
+        });
     });
 
     require('./times')(expect, request, baseUrl);
@@ -74,11 +72,9 @@ describe('Helpers', function() {
     });
 
     beforeEach(function(done) {
-        reloadFixtures(done);
-    });
-
-    afterEach(function(done) {
-        clearDatabase(done);
+        clearDatabase(function() {
+            reloadFixtures(done);
+        });
     });
 
     var localPassport = require('../src/auth/local.js')(knex);


### PR DESCRIPTION
This allows tests to fail and not break the next round of tests. Now, for every test, it will BEFORE THE TEST clear the database and reload the fixtures.