### PR TITLE
Speed up tests with in-memory database

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -9,7 +9,7 @@ module.exports = {
   mocha: {
     client: 'sqlite3',
     connection: {
-      filename: './test.sqlite3'
+      filename: ':memory:'
     }
   }
 };

--- a/src/app.js
+++ b/src/app.js
@@ -4,8 +4,14 @@ var bodyParser = require('body-parser');
 var knexfile = require('../knexfile');
 var db = process.env.DATABASE || 'development';
 
-//Load the database (default to development)
-var knex = require('knex')(knexfile[db]);
+if (!GLOBAL.knex) {
+    //Load the database (default to development)
+    var knex = require('knex')(knexfile[db]);
+} else {
+    // use the knex connection initiated from inside the testing
+    // environment
+    var knex = GLOBAL.knex;
+}
 
 var app = express();
 app.use(bodyParser.json());


### PR DESCRIPTION
This also reduces the number of database connections from two plus one per test run to only one for the entire run.