### PR TITLE
Select times within a given date range

### DIFF
--- a/src/times.js
+++ b/src/times.js
@@ -104,7 +104,7 @@ module.exports = function(app) {
               return res.status(err.status).send(err);
             }
 
-            timesQ = timesQ.andWhere('date_worked', '>', startDate.getTime());
+            timesQ = timesQ.andWhere('date_worked', '>=', startDate.getTime());
           }
 
           if (req.query.end) {
@@ -134,18 +134,14 @@ module.exports = function(app) {
               }
             }
 
-            timesQ = timesQ.andWhere('date_worked', '<', endDate.getTime());
+            timesQ = timesQ.andWhere('date_worked', '<=', endDate.getTime());
           }
-
-          console.log(timesQ.toString());
 
           let activitiesDone = false;
           let projectsDone = false;
           let usersDone = false;
 
           timesQ.then(function(times) {
-            console.log(times.length);
-
             if (times.length === 0) {
               return res.send([]);
             }

--- a/src/times.js
+++ b/src/times.js
@@ -86,6 +86,57 @@ module.exports = function(app) {
             }));
           }
 
+          if (req.query.start) {
+            let start;
+            if (typeof req.query.start === 'string') {
+              start = req.query.start;
+            } else if (helpers.getType(req.query.start) === 'array') {
+              start = req.query.start[0];
+            } else {
+              const err = errors.errorBadQueryValue('start', req.query.start);
+              return res.status(err.status).send(err);
+            }
+
+            const startInt = Date.parse(start);
+
+            if (!startInt || startInt > Date.now()) {
+              const err = errors.errorBadQueryValue('start', req.query.start);
+              return res.status(err.status).send(err);
+            }
+
+            timesQ = timesQ.andWhere('date_worked', '>=', startInt);
+          }
+
+          if (req.query.end) {
+            let end;
+            if (typeof req.query.end === 'string') {
+              end = req.query.end;
+            } else if (helpers.getType(req.query.end) === 'array') {
+              end = req.query.end[0];
+            } else {
+              const err = errors.errorBadQueryValue('end', req.query.end);
+              return res.status(err.status).send(err);
+            }
+
+            const endInt = Date.parse(end);
+
+            if (!endInt) {
+              const err = errors.errorBadQueryValue('end', req.query.end);
+              return res.status(err.status).send(err);
+            }
+
+            if (req.query.start) {
+              const startInt = Date.parse(req.query.start);
+
+              if (startInt >= endInt) {
+                const err = errors.errorBadQueryValue('end', req.query.end);
+                return res.status(err.status).send(err);
+              }
+            }
+
+            timesQ = timesQ.andWhere('date_worked', '<=', endInt);
+          }
+
           let activitiesDone = false;
           let projectsDone = false;
           let usersDone = false;

--- a/src/times.js
+++ b/src/times.js
@@ -90,7 +90,8 @@ module.exports = function(app) {
             let start;
             if (typeof req.query.start === 'string') {
               start = req.query.start;
-            } else if (helpers.getType(req.query.start) === 'array') {
+            } else if (helpers.getType(req.query.start) === 'array' &&
+                       helpers.getType(req.query.start[0]) === 'string') {
               start = req.query.start[0];
             } else {
               const err = errors.errorBadQueryValue('start', req.query.start);
@@ -111,7 +112,8 @@ module.exports = function(app) {
             let end;
             if (typeof req.query.end === 'string') {
               end = req.query.end;
-            } else if (helpers.getType(req.query.end) === 'array') {
+            } else if (helpers.getType(req.query.end) === 'array' &&
+                       helpers.getType(req.query.end[0]) === 'string') {
               end = req.query.end[0];
             } else {
               const err = errors.errorBadQueryValue('end', req.query.end);

--- a/src/times.js
+++ b/src/times.js
@@ -98,6 +98,11 @@ module.exports = function(app) {
               return res.status(err.status).send(err);
             }
 
+            if (!/\d{4}-\d{2}-\d{2}/.test(start)) {
+              const err = errors.errorBadQueryValue('start', req.query.start);
+              return res.status(err.status).send(err);
+            }
+
             const startDate = new Date(start);
 
             if (!startDate || !startDate.getTime() || startDate.getTime() > Date.now()) {
@@ -121,6 +126,11 @@ module.exports = function(app) {
             }
 
             const endDate = new Date(end);
+
+            if (!/\d{4}-\d{2}-\d{2}/.test(end)) {
+              const err = errors.errorBadQueryValue('start', req.query.start);
+              return res.status(err.status).send(err);
+            }
 
             if (!endDate || !endDate.getTime()) {
               const err = errors.errorBadQueryValue('end', req.query.end);

--- a/src/times.js
+++ b/src/times.js
@@ -97,14 +97,14 @@ module.exports = function(app) {
               return res.status(err.status).send(err);
             }
 
-            const startInt = Date.parse(start);
+            const startDate = new Date(start);
 
-            if (!startInt || startInt > Date.now()) {
+            if (!startDate || !startDate.getTime() || startDate.getTime() > Date.now()) {
               const err = errors.errorBadQueryValue('start', req.query.start);
               return res.status(err.status).send(err);
             }
 
-            timesQ = timesQ.andWhere('date_worked', '>=', startInt);
+            timesQ = timesQ.andWhere('date_worked', '>', startDate.getTime());
           }
 
           if (req.query.end) {
@@ -118,9 +118,9 @@ module.exports = function(app) {
               return res.status(err.status).send(err);
             }
 
-            const endInt = Date.parse(end);
+            const endDate = new Date(end);
 
-            if (!endInt) {
+            if (!endDate || !endDate.getTime()) {
               const err = errors.errorBadQueryValue('end', req.query.end);
               return res.status(err.status).send(err);
             }
@@ -128,20 +128,24 @@ module.exports = function(app) {
             if (req.query.start) {
               const startInt = Date.parse(req.query.start);
 
-              if (startInt >= endInt) {
+              if (startInt >= endDate.getTime()) {
                 const err = errors.errorBadQueryValue('end', req.query.end);
                 return res.status(err.status).send(err);
               }
             }
 
-            timesQ = timesQ.andWhere('date_worked', '<=', endInt);
+            timesQ = timesQ.andWhere('date_worked', '<', endDate.getTime());
           }
+
+          console.log(timesQ.toString());
 
           let activitiesDone = false;
           let projectsDone = false;
           let usersDone = false;
 
           timesQ.then(function(times) {
+            console.log(times.length);
+
             if (times.length === 0) {
               return res.send([]);
             }

--- a/tests/times.js
+++ b/tests/times.js
@@ -180,7 +180,7 @@ module.exports = function(expect, request, baseUrl) {
         const expectedResults = {
           status: 400,
           error: 'Bad Query Value',
-          text: 'Parameter project contained invalid value "notreal"',
+          text: 'Parameter project contained invalid value notreal',
         };
 
         expect(getErr).to.be.a('null');
@@ -319,7 +319,7 @@ module.exports = function(expect, request, baseUrl) {
         const expectedResults = {
           status: 400,
           error: 'Bad Query Value',
-          text: 'Parameter start contained invalid value "faux"',
+          text: 'Parameter start contained invalid value faux',
         };
 
         expect(getErr).to.be.a('null');
@@ -335,7 +335,7 @@ module.exports = function(expect, request, baseUrl) {
         const expectedResults = {
           status: 400,
           error: 'Bad Query Value',
-          text: 'Parameter start contained invalid value 2015-04-19',
+          text: 'Parameter start contained invalid value 2105-04-19',
         };
 
         expect(getErr).to.be.a('null');
@@ -411,7 +411,7 @@ module.exports = function(expect, request, baseUrl) {
         const expectedResults = {
           status: 400,
           error: 'Bad Query Value',
-          text: 'Parameter end contained invalid value "namaak"',
+          text: 'Parameter end contained invalid value namaak',
         };
 
         expect(getErr).to.be.a('null');
@@ -480,9 +480,9 @@ module.exports = function(expect, request, baseUrl) {
         expect(jsonBody.error).to.equal('Bad Query Value');
 
         expect([
-          'Parameter end contained invalid value "2015-04-19"',
-          'Parameter start contained invalid value "2015-04-21"',
-        ]).to.include.members(jsonBody.text);
+          'Parameter end contained invalid value 2015-04-19',
+          'Parameter start contained invalid value 2015-04-21',
+        ]).to.include.members([jsonBody.text]);
         done();
       });
     });

--- a/tests/times.js
+++ b/tests/times.js
@@ -59,7 +59,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(JSON.parse(getBody)).to.deep.have.same.members(expectedResults);
+        expect(JSON.parse(getBody)).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -106,7 +106,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -169,7 +169,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -232,7 +232,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -308,7 +308,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -400,7 +400,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -464,7 +464,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -542,7 +542,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -578,7 +578,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -615,7 +615,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -651,7 +651,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -687,7 +687,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -724,7 +724,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -772,7 +772,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -809,7 +809,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -846,7 +846,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -895,7 +895,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -945,7 +945,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1005,7 +1005,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1042,7 +1042,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1079,7 +1079,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1117,7 +1117,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1156,7 +1156,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1207,7 +1207,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1246,7 +1246,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1285,7 +1285,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.have.same.members(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResults);
         done();
       });
     });
@@ -1455,7 +1455,7 @@ module.exports = function(expect, request, baseUrl) {
           ]);
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.deep.have.same.members(expectedResults);
+          expect(JSON.parse(getBody)).to.deep.equal(expectedResults);
           done();
         });
       });
@@ -2014,7 +2014,7 @@ module.exports = function(expect, request, baseUrl) {
           ]);
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.deep.have.same.members(expectedResults);
+          expect(JSON.parse(getBody)).to.deep.equal(expectedResults);
           done();
         });
       });

--- a/tests/times.js
+++ b/tests/times.js
@@ -59,7 +59,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(JSON.parse(getBody)).to.have.same.members(expectedResults);
+        expect(JSON.parse(getBody)).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1455,7 +1455,7 @@ module.exports = function(expect, request, baseUrl) {
           ]);
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.have.same.members(expectedResults);
+          expect(JSON.parse(getBody)).to.deep.have.same.members(expectedResults);
           done();
         });
       });
@@ -1488,7 +1488,7 @@ module.exports = function(expect, request, baseUrl) {
         request.get(baseUrl + 'times', function(getErr, getRes, getBody) {
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.have.same.members(initialData);
+          expect(JSON.parse(getBody)).to.deep.have.same.members(initialData);
           done();
         });
       });
@@ -1682,7 +1682,7 @@ module.exports = function(expect, request, baseUrl) {
         request.get(baseUrl + 'times', function(getErr, getRes, getBody) {
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.have.same.members(initialData);
+          expect(JSON.parse(getBody)).to.deep.have.same.members(initialData);
           done();
         });
       });
@@ -2014,7 +2014,7 @@ module.exports = function(expect, request, baseUrl) {
           ]);
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.have.same.members(expectedResults);
+          expect(JSON.parse(getBody)).to.deep.have.same.members(expectedResults);
           done();
         });
       });

--- a/tests/times.js
+++ b/tests/times.js
@@ -59,7 +59,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(JSON.parse(getBody)).to.deep.equal(expectedResults);
+        expect(JSON.parse(getBody)).to.have.same.members(expectedResults);
         done();
       });
     });
@@ -106,7 +106,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -114,7 +114,7 @@ module.exports = function(expect, request, baseUrl) {
     it('returns an error for a non-existent user', function(done) {
       request.get(baseUrl + 'times?user=fakeuser', function(getErr, getRes, getBody) {
         const jsonBody = JSON.parse(getBody);
-        const expectedResults = {
+        const expectedResult = {
           status: 400,
           error: 'Bad Query Value',
           text: 'Parameter user contained invalid value fakeuser',
@@ -122,7 +122,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(400);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResult);
         done();
       });
     });
@@ -169,7 +169,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -177,7 +177,7 @@ module.exports = function(expect, request, baseUrl) {
     it('returns an error for a non-existent project', function(done) {
       request.get(baseUrl + 'times?project=notreal', function(getErr, getRes, getBody) {
         const jsonBody = JSON.parse(getBody);
-        const expectedResults = {
+        const expectedResult = {
           status: 400,
           error: 'Bad Query Value',
           text: 'Parameter project contained invalid value notreal',
@@ -185,7 +185,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(400);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResult);
         done();
       });
     });
@@ -232,7 +232,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -240,7 +240,7 @@ module.exports = function(expect, request, baseUrl) {
     it('returns an error for a non-existent activity', function(done) {
       request.get(baseUrl + 'times?activity=falsch', function(getErr, getRes, getBody) {
         const jsonBody = JSON.parse(getBody);
-        const expectedResults = {
+        const expectedResult = {
           status: 400,
           error: 'Bad Query Value',
           text: 'Parameter activity contained invalid value falsch',
@@ -248,7 +248,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(400);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResult);
         done();
       });
     });
@@ -308,7 +308,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -316,7 +316,7 @@ module.exports = function(expect, request, baseUrl) {
     it('returns an error for an invalid start date', function(done) {
       request.get(baseUrl + 'times?start=faux', function(getErr, getRes, getBody) {
         const jsonBody = JSON.parse(getBody);
-        const expectedResults = {
+        const expectedResult = {
           status: 400,
           error: 'Bad Query Value',
           text: 'Parameter start contained invalid value faux',
@@ -324,7 +324,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(400);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResult);
         done();
       });
     });
@@ -340,7 +340,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(400);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -400,7 +400,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -408,7 +408,7 @@ module.exports = function(expect, request, baseUrl) {
     it('returns an error for an invalid end date', function(done) {
       request.get(baseUrl + 'times?end=namaak', function(getErr, getRes, getBody) {
         const jsonBody = JSON.parse(getBody);
-        const expectedResults = {
+        const expectedResult = {
           status: 400,
           error: 'Bad Query Value',
           text: 'Parameter end contained invalid value namaak',
@@ -416,7 +416,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(400);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.equal(expectedResult);
         done();
       });
     });
@@ -464,7 +464,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -542,7 +542,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -578,7 +578,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -615,7 +615,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -651,7 +651,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -687,7 +687,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -724,7 +724,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -772,7 +772,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -809,7 +809,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -846,7 +846,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -895,7 +895,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -945,7 +945,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1005,7 +1005,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1042,7 +1042,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1079,7 +1079,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1117,7 +1117,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1156,7 +1156,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1207,7 +1207,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1246,7 +1246,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1285,7 +1285,7 @@ module.exports = function(expect, request, baseUrl) {
 
         expect(getErr).to.be.a('null');
         expect(getRes.statusCode).to.equal(200);
-        expect(jsonBody).to.deep.equal(expectedResults);
+        expect(jsonBody).to.deep.have.same.members(expectedResults);
         done();
       });
     });
@@ -1455,7 +1455,7 @@ module.exports = function(expect, request, baseUrl) {
           ]);
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.deep.equal(expectedResults);
+          expect(JSON.parse(getBody)).to.have.same.members(expectedResults);
           done();
         });
       });
@@ -1488,7 +1488,7 @@ module.exports = function(expect, request, baseUrl) {
         request.get(baseUrl + 'times', function(getErr, getRes, getBody) {
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.deep.equal(initialData);
+          expect(JSON.parse(getBody)).to.have.same.members(initialData);
           done();
         });
       });
@@ -1682,7 +1682,7 @@ module.exports = function(expect, request, baseUrl) {
         request.get(baseUrl + 'times', function(getErr, getRes, getBody) {
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.deep.equal(initialData);
+          expect(JSON.parse(getBody)).to.have.same.members(initialData);
           done();
         });
       });
@@ -2014,7 +2014,7 @@ module.exports = function(expect, request, baseUrl) {
           ]);
           expect(getErr).to.be.a('null');
           expect(getRes.statusCode).to.equal(200);
-          expect(JSON.parse(getBody)).to.deep.equal(expectedResults);
+          expect(JSON.parse(getBody)).to.have.same.members(expectedResults);
           done();
         });
       });


### PR DESCRIPTION
Allow a user to select times only within a given date range, using start and end query parameters. Fixes issue #131.