### PR TITLE
add production database environment

### DIFF
--- a/docs/source/dev/development.rst
+++ b/docs/source/dev/development.rst
@@ -64,6 +64,30 @@ Some other commands have been made available through TimeSync's
     * ``npm run linter``: run the jshint Javascript linter
     * ``npm run fixtures``: install a set of test fixtures
 
+Databases
+---------
+
+TimeSync supports multiple kinds of database connections. For testing, it uses a
+``SQLite`` database in-memory, for development, it uses a ``SQLite`` database on
+the filesystem, and in production, it uses a ``PostgreSQL`` database. Since it's
+not a good idea to use a totally different database server without testing it
+first, it's a good idea to make sure your changes work on Postgres as well.
+
+To use the Postgres database, first set your ``NODE_ENV`` to ``production``::
+
+    $ export NODE_ENV="production"
+
+Then, set the ``PG_CONNECTION_STRING`` environment variable to a Postgres
+connection string, which looks something like this::
+
+    $ export PG_CONNECTION_STIRNG="postgres://username:password@server:port/db_name"
+
+For instance, if you're running an instance of Postgres locally with the
+username and password ``timesync`` accessing the database ``timesync``, the
+string should look like this::
+
+    postgres://timesync:timesync@localhost:5432/timesync
+
 Testing
 -------
 

--- a/knexfile.js
+++ b/knexfile.js
@@ -11,5 +11,10 @@ module.exports = {
     connection: {
       filename: ':memory:'
     }
-  }
+  },
+
+  production: {
+    client: 'pg',
+    connection: process.env.PG_CONNECTION_STRING
+  },
 };

--- a/migrations/20150101000000_00.js
+++ b/migrations/20150101000000_00.js
@@ -1,7 +1,12 @@
 'use strict';
 
 exports.up = function(knex) {
-  return knex.schema.createTable('projects', function(table) {
+  return knex.schema.createTable('users', function(table) {
+    table.increments('id').primary();
+    table.string('username').unique().notNullable();
+    table.string('active').defaultTo(true);
+    table.string('password')
+  }).createTable('projects', function(table) {
     table.increments('id').primary();
     table.string('name').notNullable();
     table.string('uri');
@@ -19,11 +24,6 @@ exports.up = function(knex) {
     table.increments('id').primary();
     table.string('name').unique().notNullable();
     table.string('slug').unique().notNullable();
-  }).createTable('users', function(table) {
-    table.increments('id').primary();
-    table.string('username').unique().notNullable();
-    table.string('active').defaultTo(true);
-    table.string('password');
   }).createTable('projectslugs', function(table) {
     table.increments('id').primary();
     table.string('name').unique().notNullable();

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "recreate": "rm dev.sqlite3 && knex migrate:latest",
     "linter": "jshint ./src ./tests ./scripts && eslint ./src ./tests ./scripts",
     "fixtures": "node --harmony ./scripts/load_fixtures.js",
-    "test": "DATABASE=mocha PORT=8851 DEBUG=true mocha --harmony tests",
+    "test": "NODE_ENV=mocha PORT=8851 DEBUG=true mocha --harmony tests",
     "latte": "sh ./scripts/latte.sh",
-    "coverage": "DATABASE=mocha PORT=8851 DEBUG=true node --harmony ./node_modules/istanbul/lib/cli.js cover _mocha -- tests",
+    "coverage": "NODE_ENV=mocha PORT=8851 DEBUG=true node --harmony ./node_modules/istanbul/lib/cli.js cover _mocha -- tests",
     "create-account": "node --harmony ./scripts/create-account.js"
   },
   "repository": {
@@ -42,6 +42,7 @@
     "knex": "^0.8.6",
     "passport": "^0.2.2",
     "passport-local": "^1.0.0",
+    "pg": "^4.4.1",
     "prompt": "^0.2.14",
     "sqlite3": "^3.0.8",
     "valid-url": "^1.0.9"

--- a/scripts/create-account.js
+++ b/scripts/create-account.js
@@ -6,7 +6,7 @@
 const prompt = require('prompt');
 const bcrypt = require('bcrypt');
 const knexfile = require('../knexfile');
-const db = process.env.DATABASE || 'development';
+const db = process.env.NODE_ENV || 'development';
 
 // Load the database (default = development)
 const knex = require('knex')(knexfile[db]);

--- a/scripts/load_fixtures.js
+++ b/scripts/load_fixtures.js
@@ -4,8 +4,9 @@ const sqlFixtures = require('sql-fixtures');
 const knexfile = require('../knexfile');
 
 const testData = require('../tests/fixtures/test_data');
+const env = process.env.NODE_ENV || 'development';
 
-sqlFixtures.create(knexfile.development, testData).then(function quit() {
+sqlFixtures.create(knexfile[env], testData).then(function quit() {
     process.exit(0);
   }
 );

--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const knexfile = require('../knexfile');
-const db = process.env.DATABASE || 'development';
+const db = process.env.NODE_ENV || 'development';
 
 let knex;
 if (!GLOBAL.knex) {

--- a/tests/fixtures/test_data.json
+++ b/tests/fixtures/test_data.json
@@ -69,38 +69,38 @@
     {
       "name": "gwm",
       "id": 1,
-      "project": 1,
+      "project": "projects:0",
       "activity": null
     },
     {
       "name": "pgd",
       "id": 2,
-      "project": 2,
+      "project": "projects:1",
       "activity": null
     },
     {
       "name": "wf",
       "id": 3,
-      "project": 3,
+      "project": "projects:2",
       "activity": null
     },
     {
       "name": "ganeti-webmgr",
       "id": 8,
-      "project": 1,
+      "project": "projects:0",
       "activity": null
     }
   ],
   "timesactivities":[
     {
       "id": 1,
-      "time": 1,
-      "activity": 1
+      "time": "times:0",
+      "activity": "activities:0"
     },
     {
       "id": 2,
-      "time": 1,
-      "activity": 2
+      "time": "times:0",
+      "activity": "activities:1"
     }
   ]
 }


### PR DESCRIPTION
This required updating the fixtures as well, since many of them took
advantage of sqlite being lazy and allowing bad foreign keys.

It also moves everything over to the NODE_ENV variable, which is the
"blessed" way of doing this kind of config.