### PR TITLE
re-added timesync gitsubmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "timesync-api"]
 	path = timesync-api
-	url = git@github.com:osuosl/timesync.git
+	url = https://github.com/osuosl/timesync.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "timesync-api"]
 	path = timesync-api
 	url = https://github.com/osuosl/timesync.git
+    branch = master


### PR DESCRIPTION
resolves #159 

How to initialize the new API (assuming a clean clone of the ``timesync-node`` repo on the ``elijah/readd-api`` branch [but it should work just fine on an existing clone])
```
[timesync-api/]$ git submodule init .  # This initializes the git submodules in the repo (there's only one)
Submodule 'timesync-api' (https://github.com/osuosl/timesync.git) registered for path 'timesync-api'
[timesync-api/]$ git submodule update .  # This clones the submodule and sets it to be
Cloning into 'timesync-api'...
remote: Counting objects: 1028, done.
remote: Compressing objects: 100% (32/32), done.
remote: Total 1028 (delta 158), reused 135 (delta 135), pack-reused 861
Receiving objects: 100% (1028/1028), 146.66 KiB | 0 bytes/s, done.
Resolving deltas: 100% (542/542), done.
Checking connectivity... done.
Submodule path 'timesync-api': checked out 'a7efe7a116e3f50859e2f76a13c6289258501aee'
```