### PR TITLE
Create Docker Container for our Databse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 docs/build/
 jsreport/
 coverage/
+venv/

--- a/Dockerfile-db
+++ b/Dockerfile-db
@@ -1,0 +1,3 @@
+FROM postgres:9.0
+MAINTAINER OSU Open Source Lab
+EXPOSE 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+db:
+    build: .
+    dockerfile: Dockerfile-db
+    environment:
+        - POSTGRES_PASSWORD=postgres
+    ports:
+        - "5432:5432"

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,16 +1,12 @@
 module.exports = {
   development: {
-    client: 'sqlite3',
-    connection: {
-      filename: './dev.sqlite3'
-    }
+    client: 'pg',
+    connection: process.env.PG_CONNECTION_STRING
   },
 
   mocha: {
-    client: 'sqlite3',
-    connection: {
-      filename: ':memory:'
-    }
+    client: 'pg',
+    connection: process.env.PG_CONNECTION_STRING
   },
 
   production: {
@@ -18,3 +14,4 @@ module.exports = {
     connection: process.env.PG_CONNECTION_STRING
   },
 };
+

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "NODE_ENV=mocha PORT=8851 DEBUG=true mocha --harmony tests",
     "latte": "sh ./scripts/latte.sh",
     "coverage": "NODE_ENV=mocha PORT=8851 DEBUG=true node --harmony ./node_modules/istanbul/lib/cli.js cover _mocha -- tests",
-    "create-account": "node --harmony ./scripts/create-account.js"
+    "create-account": "node --harmony ./scripts/create-account.js",
+    "docker-test": "sh ./scripts/docker-test.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+docker-compose run -d db
+psql postgres://postgres:postgres@localhost:5432 --command="CREATE DATABASE timesync;"
+export PG_CONNECTION_STRING=postgres://postgres:postgres@localhost:5432/timesync
+npm run migrations
+npm test


### PR DESCRIPTION
This commit adds the following files with corresponding reasons:
- Docker-db: Sets up a docker container with postgres 9.0
- docker-compose.yml: contains `db` runlist, starts the database and
  exposes the appropriate ports & environment variables
- scritps/docker-test.js automatically spins up a docker container for
  the database and runs the testing commands.

The following files were changed for the corresponding reasons:
- .gitignore ignores a `venv/` directory
- knexfile.js uses postgres now.
- package.json adds a docker-test command

Setup:
```
$ virtualenv venv
$ source venv/bin/activate
$ pip install docker-compose=1.3.3
```
Now you should be able to run ``npm run docker-test`` and watch everything break!

Resolves #172