### PR TITLE
Add default activities for projects.

### DIFF
--- a/migrations/20150101000000_00.js
+++ b/migrations/20150101000000_00.js
@@ -19,7 +19,7 @@ exports.up = function(knex) {
     table.increments('id').primary();
     table.string('name').notNullable();
     table.string('uri');
-    table.integer('default_activity').references('id').inTable('activity');
+    table.integer('default_activity').references('id').inTable('activities');
     table.bigInteger('created_at').notNullable();
     table.bigInteger('updated_at').defaultTo(null);
     table.bigInteger('deleted_at').defaultTo(null);

--- a/migrations/20150101000000_00.js
+++ b/migrations/20150101000000_00.js
@@ -19,6 +19,7 @@ exports.up = function(knex) {
     table.increments('id').primary();
     table.string('name').notNullable();
     table.string('uri');
+    table.integer('default_activity').references('id').inTable('activity');
     table.bigInteger('created_at').notNullable();
     table.bigInteger('updated_at').defaultTo(null);
     table.bigInteger('deleted_at').defaultTo(null);

--- a/migrations/20150101000000_00.js
+++ b/migrations/20150101000000_00.js
@@ -15,6 +15,16 @@ exports.up = function(knex) {
     table.bigInteger('updated_at').defaultTo(null);
     table.bigInteger('deleted_at').defaultTo(null);
     table.text('meta');
+  }).createTable('activities', function(table) {
+    table.increments('id').primary();
+    table.string('name').notNullable();
+    table.string('slug');
+    table.bigInteger('created_at').notNullable();
+    table.bigInteger('updated_at').defaultTo(null);
+    table.bigInteger('deleted_at').defaultTo(null);
+    table.uuid('uuid');
+    table.integer('revision').defaultTo(1);
+    table.boolean('newest').defaultTo(true);
   }).createTable('projects', function(table) {
     table.increments('id').primary();
     table.string('name').notNullable();
@@ -34,16 +44,6 @@ exports.up = function(knex) {
     table.string('notes');
     table.string('issue_uri');
     table.bigInteger('date_worked');
-    table.bigInteger('created_at').notNullable();
-    table.bigInteger('updated_at').defaultTo(null);
-    table.bigInteger('deleted_at').defaultTo(null);
-    table.uuid('uuid');
-    table.integer('revision').defaultTo(1);
-    table.boolean('newest').defaultTo(true);
-  }).createTable('activities', function(table) {
-    table.increments('id').primary();
-    table.string('name').notNullable();
-    table.string('slug');
     table.bigInteger('created_at').notNullable();
     table.bigInteger('updated_at').defaultTo(null);
     table.bigInteger('deleted_at').defaultTo(null);

--- a/src/authenticatedRequest.js
+++ b/src/authenticatedRequest.js
@@ -38,7 +38,8 @@ module.exports = {
       const caller = function(autherr, user, info) {
         if (!user) {
           const err = errors.errorAuthenticationFailure(autherr ||
-                                                                  info.message);
+                                                        info.message ||
+                                                        'Unknown error');
           return res.status(err.status).send(err);
         }
         callback(req, res, user);
@@ -58,7 +59,8 @@ module.exports = {
       const caller = function(autherr, user, info) {
         if (!user) {
           const err = errors.errorAuthenticationFailure(autherr ||
-                                                                  info.message);
+                                                        info.message ||
+                                                        'Unknown error');
           return res.status(err.status).send(err);
         }
         callback(req, res, user);
@@ -78,7 +80,8 @@ module.exports = {
       const caller = function(autherr, user, info) {
         if (!user) {
           const err = errors.errorAuthenticationFailure(autherr ||
-                                                                  info.message);
+                                                        info.message ||
+                                                        'Unknown error');
           return res.status(err.status).send(err);
         }
         callback(req, res, user);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -79,12 +79,18 @@ module.exports = function(app) {
         /* eslint-enable prefer-const */
         const fieldValue = helpers.getType(object[field.name]);
         if (fieldValue !== field.type) {
-          if (object[field.name] === undefined && !field.required) {
-            // if the field isn't required, and it's undefined,
-            // skip it
-            continue;
+          if (object[field.name] === undefined) {
+            if (!field.required) {
+              // if the field isn't required, and it's undefined,
+              // skip it
+              continue;
+            } else {
+              field.missing = true;
+              return field;
+            }
           }
 
+          field.missing = false;
           field.actualType = fieldValue;
           return field;
         }

--- a/src/login.js
+++ b/src/login.js
@@ -137,6 +137,8 @@ module.exports = function(app) {
 
             resolve(payload.sub);
           });
+        } else {
+          return reject({message: 'Unsupported algorithm'});
         }
       });
     },

--- a/src/login.js
+++ b/src/login.js
@@ -138,7 +138,8 @@ module.exports = function(app) {
             resolve(payload.sub);
           });
         } else {
-          return reject({message: 'Unsupported algorithm'});
+          return reject({message: 'Unsupported token crypto-algorithm: ' +
+                                                                  header.alg});
         }
       });
     },

--- a/src/projects.js
+++ b/src/projects.js
@@ -692,6 +692,7 @@ module.exports = function(app) {
                         for (let userId of userIds) {
                           userMap[userId.username] = userId.id;
                         }
+
                         /* eslint-disable guard-for-in */
                         for (let username in obj.users) {
                         /* eslint-enable prefer-const */

--- a/src/times.js
+++ b/src/times.js
@@ -645,6 +645,7 @@ module.exports = function(app) {
               return res.status(err.status).send(err);
             });
           }).catch(function(error) {
+            log.error(req, 'Error retrieving user roles: ' + error);
             const err = errors.errorServerError(error);
             return res.status(err.status).send(err);
           });

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -29,6 +29,6 @@ projects.
   - Member of: WF
 
 6) MaraJade's password is ``wording``
-- Project manager for: Chili Project (deleted) and GWM
-- Member of: Chili Project and GWM
-- Spectator of: Chili Project and GWM
+  - Project manager for: Chili Project (deleted) and GWM
+  - Member of: Chili Project and GWM
+  - Spectator of: Chili Project and GWM

--- a/tests/fixtures/test_data.json
+++ b/tests/fixtures/test_data.json
@@ -153,6 +153,7 @@
     {
       "uri":"https:://code.osuosl.org/projects/ganeti-webmgr",
       "name":"Ganeti Web Manager",
+      "default_activity": null,
       "id": 1,
       "uuid": "c285963e-192b-4e99-9d92-a940519f1fbd",
       "revision": 1,
@@ -164,6 +165,7 @@
     {
       "uri":"https:://code.osuosl.org/projects/pgd",
       "name":"Protein Geometry Database",
+      "default_activity": null,
       "id": 2,
       "uuid": "e3e25e6a-5e45-4df2-8561-796b07e8f974",
       "revision": 1,
@@ -175,6 +177,7 @@
     {
       "uri":"https:://github.com/osu-cass/whats-fresh-api",
       "name":"Whats Fresh",
+      "default_activity": null,
       "id": 3,
       "uuid": "9369f959-26f2-490d-8721-2948c49c3c09",
       "revision": 1,
@@ -186,6 +189,7 @@
     {
       "uri":"https:://github.com/osuosl/timesync",
       "name":"Timesync",
+      "default_activity": "activities:1",
       "id": 4,
       "uuid": "1f8788bd-0909-4397-be2c-79047f90c575",
       "revision": 1,
@@ -197,6 +201,7 @@
     {
       "uri":"https:://github.com/osuosl/chiliproject",
       "name":"Chili Project",
+      "default_activity": null,
       "id": 5,
       "uuid": "6abe7f9a-2c4b-4c1d-b4f9-1222b47b8a29",
       "revision": 1,
@@ -452,6 +457,13 @@
     },
     {
       "project":"projects:3",
+      "user":"users:1",
+      "manager": false,
+      "member": true,
+      "spectator": false
+    },
+    {
+      "project":"projects:4",
       "user":"users:2",
       "manager": true,
       "member": true,
@@ -459,8 +471,8 @@
     },
     {
       "project":"projects:4",
-      "user":"users:5",
-      "manager": true,
+      "user":"users:1",
+      "manager": false,
       "member": true,
       "spectator": true
     },

--- a/tests/fixtures/test_data.json
+++ b/tests/fixtures/test_data.json
@@ -457,13 +457,6 @@
     },
     {
       "project":"projects:3",
-      "user":"users:1",
-      "manager": false,
-      "member": true,
-      "spectator": false
-    },
-    {
-      "project":"projects:4",
       "user":"users:2",
       "manager": true,
       "member": true,
@@ -471,8 +464,8 @@
     },
     {
       "project":"projects:4",
-      "user":"users:1",
-      "manager": false,
+      "user":"users:5",
+      "manager": true,
       "member": true,
       "spectator": true
     },

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -34,7 +34,7 @@ module.exports = function(expect, app) {
         name: 'integer',
         type: 'number',
         required: true,
-        actualType: 'undefined',
+        missing: true,
       };
 
       expect(validation).to.deep.equal(expectedReturn);
@@ -46,7 +46,7 @@ module.exports = function(expect, app) {
       const fields = [
         {name: 'string', type: 'string', required: true},
         {name: 'array', type: 'array', required: true},
-        {name: 'integer', type: 'number', required: true},
+        {name: 'integer', type: 'number', required: false},
       ];
 
       const validation = helpers.validateFields(obj, fields);
@@ -54,8 +54,9 @@ module.exports = function(expect, app) {
       const expectedReturn = {
         name: 'integer',
         type: 'number',
-        required: true,
+        required: false,
         actualType: 'string',
+        missing: false,
       };
 
       expect(validation).to.deep.equal(expectedReturn);

--- a/tests/projects.js
+++ b/tests/projects.js
@@ -37,6 +37,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://code.osuosl.org/projects/ganeti-webmgr',
       name: 'Ganeti Web Manager',
       slugs: ['ganeti-webmgr', 'gwm'],
+      default_activity: null,
       deleted_at: null,
       updated_at: null,
       created_at: '2014-01-01',
@@ -53,6 +54,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://code.osuosl.org/projects/pgd',
       name: 'Protein Geometry Database',
       slugs: ['pgd'],
+      default_activity: null,
       deleted_at: null,
       updated_at: null,
       created_at: '2014-01-01',
@@ -67,6 +69,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://github.com/osu-cass/whats-fresh-api',
       name: 'Whats Fresh',
       slugs: ['wf'],
+      default_activity: null,
       deleted_at: null,
       updated_at: null,
       created_at: '2014-01-01',
@@ -82,6 +85,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://github.com/osuosl/timesync',
       name: 'Timesync',
       slugs: ['timesync', 'ts'],
+      default_activity: 'dev',
       deleted_at: null,
       updated_at: null,
       created_at: '2014-01-01',
@@ -95,6 +99,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://github.com/osuosl/chiliproject',
       name: 'Chili Project',
       slugs: [],
+      default_activity: null,
       deleted_at: '2014-01-01',
       updated_at: null,
       created_at: '2009-07-07',
@@ -199,6 +204,7 @@ module.exports = function(expect, request, baseUrl) {
         request.get(baseUrl + 'projects/gwm?token=' + token,
         function(err, res, body) {
           const jsonBody = JSON.parse(body);
+
           expect(err).to.equal(null);
           expect(res.statusCode).to.equal(200);
 
@@ -254,11 +260,13 @@ module.exports = function(expect, request, baseUrl) {
       name: 'Ganeti Web Mgr',
       slugs: ['gan-web', 'gwm'],
       uri: 'https://code.osuosl.org/projects/',
+      default_activity: 'docs',
     };
 
     const originalProject = {
       name: 'Ganeti Web Manager',
       slugs: ['ganeti-webmgr', 'gwm'],
+      default_activity: null,
       deleted_at: null,
       updated_at: null,
       created_at: '2014-01-01',
@@ -276,6 +284,8 @@ module.exports = function(expect, request, baseUrl) {
     const patchedProjectName = {name: patchedProject.name};
     const patchedProjectUri = {uri: patchedProject.uri};
     const patchedProjectSlugs = {slugs: patchedProject.slugs};
+    const patchedProjectActivity =
+            {default_activity: patchedProject.default_activity};
     const patchedProjectNewMember = {users: {
       tschuy: {member: true, spectator: true, manager: true},
       mrsj: {member: true, spectator: true, manager: false},
@@ -306,12 +316,14 @@ module.exports = function(expect, request, baseUrl) {
       name: ['a name'],
       uri: ['a website'],
       slugs: 'a slug',
+      default_activity: [100],
       key: 'value',
     };
 
     const badProjectName = {name: badProject.name};
     const badProjectUri = {uri: badProject.uri};
     const badProjectSlugs = {slugs: badProject.slugs};
+    const badProjectActivity = {default_activity: badProject.default_activity};
     const badProjectKey = {key: 'value' };
 
     const postArg = {
@@ -341,7 +353,8 @@ module.exports = function(expect, request, baseUrl) {
       });
     };
 
-    it("successfully patches a project's uri, slugs, and name by an admin",
+    it("successfully patches a project's uri, slugs, name, and default " +
+    'activity by an admin',
     function(done) {
       getAPIToken().then(function(token) {
         requestOptions.body = copyJsonObject(postArg);
@@ -358,6 +371,7 @@ module.exports = function(expect, request, baseUrl) {
           expectedResults.name = patchedProject.name;
           expectedResults.uri = patchedProject.uri;
           expectedResults.slugs = patchedProject.slugs;
+          expectedResults.default_activity = patchedProject.default_activity;
           expectedResults.uuid = originalProject.uuid;
           expectedResults.revision = 2;
           expectedResults.updated_at = new Date().toISOString()
@@ -668,6 +682,36 @@ module.exports = function(expect, request, baseUrl) {
       });
     });
 
+    it("successfully patches a project's default activity", function(done) {
+      getAPIToken().then(function(token) {
+        requestOptions.body = copyJsonObject(postArg);
+        requestOptions.body.object = copyJsonObject(patchedProjectActivity);
+
+        requestOptions.body.auth.token = token;
+
+        request.post(requestOptions, function(err, res, body) {
+          expect(err).to.be.a('null');
+          expect(res.statusCode).to.equal(200);
+
+          const expectedResults = copyJsonObject(originalProject);
+          expectedResults.default_activity = patchedProject.default_activity;
+          expectedResults.uuid = originalProject.uuid;
+          expectedResults.revision = 2;
+          expectedResults.id = 6;
+          expectedResults.updated_at = new Date().toISOString()
+                                                 .substring(0, 10);
+
+          const expectedPost = copyJsonObject(expectedResults);
+          delete expectedPost.deleted_at;
+
+          // expect body of post request to be the new state of gwm
+          expect(body).to.deep.equal(expectedPost);
+
+          checkListEndpoint(done, expectedResults, token);
+        });
+      });
+    });
+
     it("doesn't patch a project with bad authentication", function(done) {
       getAPIToken().then(function(token) {
         requestOptions.body = copyJsonObject(postArg);
@@ -715,7 +759,8 @@ module.exports = function(expect, request, baseUrl) {
       });
     });
 
-    it("doesn't patch a project with bad uri, name, and slugs",
+    it("doesn't patch a project with bad uri, name, slugs, and default " +
+    'activity',
     function(done) {
       getAPIToken().then(function(token) {
         requestOptions.body = copyJsonObject(postArg);
@@ -734,6 +779,8 @@ module.exports = function(expect, request, baseUrl) {
             'array',
             'Field slugs of project should be array but was sent as ' +
             'string',
+            'Field default_activity of project should be string but was sent' +
+            ' as number',
             'project does not have a key field',
           ]).to.include.members([body.text]);
 
@@ -793,6 +840,26 @@ module.exports = function(expect, request, baseUrl) {
           expect(res.statusCode).to.equal(400);
           expect(body.text).to.equal('Field name of' +
           ' project should be string but was sent as array');
+
+          const expectedResults = copyJsonObject(originalProject);
+          checkListEndpoint(done, expectedResults, token);
+        });
+      });
+    });
+
+    it("doesn't patch a project with just bad default activity",
+    function(done) {
+      getAPIToken().then(function(token) {
+        requestOptions.body = copyJsonObject(postArg);
+        requestOptions.body.object = copyJsonObject(badProjectActivity);
+
+        requestOptions.body.auth.token = token;
+
+        request.post(requestOptions, function(err, res, body) {
+          expect(body.error).to.equal('Bad object');
+          expect(res.statusCode).to.equal(400);
+          expect(body.text).to.equal('Field default_activity of project ' +
+          'should be string but was sent as array');
 
           const expectedResults = copyJsonObject(originalProject);
           checkListEndpoint(done, expectedResults, token);
@@ -970,6 +1037,61 @@ module.exports = function(expect, request, baseUrl) {
       });
     });
 
+    it("doesn't patch a project with non-existent default activity",
+    function(done) {
+      getAPIToken().then(function(token) {
+        requestOptions.body = copyJsonObject(postArg);
+        requestOptions.body.object = copyJsonObject(originalProject);
+        delete requestOptions.body.object.id;
+        delete requestOptions.body.object.uuid;
+        delete requestOptions.body.object.revision;
+        delete requestOptions.body.object.deleted_at;
+        delete requestOptions.body.object.updated_at;
+        delete requestOptions.body.object.created_at;
+        requestOptions.body.object.default_activity = 'not_an_activity';
+
+        requestOptions.body.auth.token = token;
+
+        request.post(requestOptions, function(err, res, body) {
+          expect(body.error).to.equal('Invalid foreign key');
+          expect(res.statusCode).to.equal(409);
+          expect(body.text).to.equal('The project does not contain a valid ' +
+          'activity reference.');
+
+          const expectedResults = copyJsonObject(originalProject);
+          checkListEndpoint(done, expectedResults, token);
+        });
+      });
+    });
+
+    it("doesn't patch a project with wrong-type default activity",
+    function(done) {
+      getAPIToken().then(function(token) {
+        requestOptions.body = copyJsonObject(postArg);
+        requestOptions.body.object = copyJsonObject(originalProject);
+        delete requestOptions.body.object.id;
+        delete requestOptions.body.object.uuid;
+        delete requestOptions.body.object.revision;
+        delete requestOptions.body.object.deleted_at;
+        delete requestOptions.body.object.updated_at;
+        delete requestOptions.body.object.created_at;
+        requestOptions.body.object.default_activity =
+                                                    badProject.default_activity;
+
+        requestOptions.body.auth.token = token;
+
+        request.post(requestOptions, function(err, res, body) {
+          expect(body.error).to.equal('Bad object');
+          expect(res.statusCode).to.equal(400);
+          expect(body.text).to.equal('Field default_activity of' +
+          ' project should be string but was sent as array');
+
+          const expectedResults = copyJsonObject(originalProject);
+          checkListEndpoint(done, expectedResults, token);
+        });
+      });
+    });
+
     it("doesn't patch a project with invalid key", function(done) {
       getAPIToken().then(function(token) {
         requestOptions.body = copyJsonObject(postArg);
@@ -1002,6 +1124,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://github.com/osuosl/timesync-node',
       slugs: ['timesync-node', 'tsn'],
       name: 'TimeSync Node',
+      default_activity: 'meeting',
       users: {
         patcht: {member: true, spectator: true, manager: true},
         thai: {member: true, spectator: true, manager: false},
@@ -1013,6 +1136,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://github.com/osuosl/timesync-node',
       slugs: ['timesync-node', 'tsn'],
       name: 'TimeSync Node',
+      default_activity: 'meeting',
       revision: 1,
       created_at: new Date().toISOString().substring(0, 10),
       users: {
@@ -1068,6 +1192,7 @@ module.exports = function(expect, request, baseUrl) {
               uri: 'https://github.com/osuosl/timesync-node',
               slugs: ['timesync-node', 'tsn'],
               name: 'TimeSync Node',
+              default_activity: 'meeting',
               deleted_at: null,
               updated_at: null,
               created_at: new Date().toISOString().substring(0, 10),
@@ -1113,6 +1238,7 @@ module.exports = function(expect, request, baseUrl) {
               uri: 'https://github.com/osuosl/timesync-node',
               slugs: ['timesync-node', 'tsn'],
               name: 'TimeSync Node',
+              default_activity: 'meeting',
               deleted_at: null,
               updated_at: null,
               created_at: new Date().toISOString().substring(0, 10),
@@ -1156,6 +1282,7 @@ module.exports = function(expect, request, baseUrl) {
               uri: null,
               slugs: ['timesync-node', 'tsn'],
               name: 'TimeSync Node',
+              default_activity: 'meeting',
               deleted_at: null,
               updated_at: null,
               created_at: new Date().toISOString().substring(0, 10),
@@ -1208,6 +1335,61 @@ module.exports = function(expect, request, baseUrl) {
           ]);
 
           checkListEndpoint(done, expectedGetResults, token);
+        });
+      });
+    });
+
+    it('successfully creates a new project with no default activity',
+    function(done) {
+      getAPIToken().then(function(token) {
+        // remove uri from post data
+        const postNoActivity = copyJsonObject(postArg);
+        postNoActivity.object.default_activity = undefined;
+        requestOptions.body = postNoActivity;
+
+        requestOptions.body.auth.token = token;
+
+        // remove uri from test object
+        const newProjectNoActivity = copyJsonObject(newProject);
+        delete newProjectNoActivity.default_activity;
+
+        request.post(requestOptions, function(err, res, body) {
+          expect(err).to.be.a('null');
+          expect(res.statusCode).to.equal(200);
+
+          const addedProject = copyJsonObject(newProjectNoActivity);
+          addedProject.uuid = body.uuid;
+          expect(body).to.deep.equal(addedProject);
+
+          request.get(baseUrl + 'projects?token=' + token,
+          function(getErr, getRes, getBody) {
+            // the projects/ endpoint should now have one more project
+            const expectedGetResults = initialData.concat([
+              {
+                owner: 'tschuy',
+                uri: 'https://github.com/osuosl/timesync-node',
+                slugs: ['tsn', 'timesync-node'],
+                name: 'TimeSync Node',
+                default_activity: null,
+                deleted_at: null,
+                updated_at: null,
+                created_at: new Date().toISOString().substring(0, 10),
+                revision: 1,
+                uuid: addedProject.uuid,
+                users: {
+                  patcht: {member: true, spectator: true, manager: true},
+                  thai: {member: true, spectator: true, manager: false},
+                },
+              },
+            ]);
+
+            expect(getErr).to.be.a('null');
+            expect(getRes.statusCode).to.equal(200);
+
+            const jsonBody = JSON.parse(getBody);
+            expect(jsonBody).to.deep.have.same.members(expectedGetResults);
+            done();
+          });
         });
       });
     });
@@ -1415,6 +1597,51 @@ module.exports = function(expect, request, baseUrl) {
           ' project should be string but was sent as array');
 
           checkListEndpoint(done, initialData, token);
+        });
+      });
+    });
+
+    it('fails to create a new project with non-existent default activity',
+    function(done) {
+      getAPIToken().then(function(token) {
+        const postBadActivity = copyJsonObject(postArg);
+        postBadActivity.object.default_activity = 'not_an_activity';
+        requestOptions.body = postBadActivity;
+
+        request.post(requestOptions, function(err, res, body) {
+          const expectedError = {
+            status: 409,
+            error: 'Invalid foreign key',
+            text: 'The project does not contain a valid activity reference.',
+          };
+
+          expect(body).to.deep.equal(expectedError);
+          expect(res.statusCode).to.equal(409);
+
+          checkListEndpoint(done, token);
+        });
+      });
+    });
+
+    it('fails to create a new project with bad default activity datatype',
+    function(done) {
+      getAPIToken().then(function(token) {
+        const postBadActivity = copyJsonObject(postArg);
+        postBadActivity.object.default_activity = [105];
+        requestOptions.body = postBadActivity;
+
+        request.post(requestOptions, function(err, res, body) {
+          const expectedError = {
+            status: 400,
+            error: 'Bad Object',
+            text: 'Field default_activity of project should be string but ' +
+                  'was sent as array',
+          };
+
+          expect(body).to.deep.equal(expectedError);
+          expect(res.statusCode).to.equal(400);
+
+          checkListEndpoint(done, token);
         });
       });
     });
@@ -1718,6 +1945,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://code.osuosl.org/projects/ganeti-webmgr',
       name: 'GANETI WEB MANAGER',
       uuid: 'c285963e-192b-4e99-9d92-a940519f1fbd',
+      default_activity: null,
       revision: 2,
       deleted_at: null,
       updated_at: currentTime,
@@ -1735,6 +1963,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://code.osuosl.org/projects/ganeti-webmgr',
       name: 'GANETI WEB MANAGER',
       uuid: 'c285963e-192b-4e99-9d92-a940519f1fbd',
+      default_activity: null,
       revision: 2,
       deleted_at: null,
       updated_at: currentTime,
@@ -1751,6 +1980,7 @@ module.exports = function(expect, request, baseUrl) {
           uri: 'https://code.osuosl.org/projects/ganeti-webmgr',
           name: 'Ganeti Web Manager',
           uuid: 'c285963e-192b-4e99-9d92-a940519f1fbd',
+          default_activity: null,
           revision: 1,
           deleted_at: null,
           updated_at: null,

--- a/tests/projects.js
+++ b/tests/projects.js
@@ -705,6 +705,7 @@ module.exports = function(expect, request, baseUrl) {
 
           const expectedPost = copyJsonObject(expectedResults);
           delete expectedPost.deleted_at;
+          delete expectedPost.users;
 
           // expect body of post request to be the new state of gwm
           expect(body).to.deep.equal(expectedPost);
@@ -1326,6 +1327,7 @@ module.exports = function(expect, request, baseUrl) {
               uri: 'https://github.com/osuosl/timesync-node',
               slugs: ['timesync-node', 'tsn'],
               name: 'TimeSync Node',
+              default_activity: 'meeting',
               deleted_at: null,
               updated_at: null,
               created_at: new Date().toISOString().substring(0, 10),
@@ -1617,7 +1619,7 @@ module.exports = function(expect, request, baseUrl) {
           expect(body).to.deep.equal(expectedError);
           expect(res.statusCode).to.equal(409);
 
-          checkListEndpoint(done, token);
+          checkListEndpoint(done, initialData, token);
         });
       });
     });
@@ -1640,7 +1642,7 @@ module.exports = function(expect, request, baseUrl) {
           expect(body).to.deep.equal(expectedError);
           expect(res.statusCode).to.equal(400);
 
-          checkListEndpoint(done, token);
+          checkListEndpoint(done, initialData, token);
         });
       });
     });

--- a/tests/projects.js
+++ b/tests/projects.js
@@ -389,8 +389,8 @@ module.exports = function(expect, request, baseUrl) {
       });
     });
 
-    it("successfully patches a project's uri, slugs, and name by a sitewide " +
-    'manager', function(done) {
+    it("successfully patches a project's uri, slugs, name, and " +
+    'default_activity by a sitewide manager', function(done) {
       const oldUser = user;
       const oldPass = password;
 
@@ -414,6 +414,7 @@ module.exports = function(expect, request, baseUrl) {
           expectedResults.name = patchedProject.name;
           expectedResults.uri = patchedProject.uri;
           expectedResults.slugs = patchedProject.slugs;
+          expectedResults.default_activity = patchedProject.default_activity;
           expectedResults.uuid = originalProject.uuid;
           expectedResults.revision = 2;
           expectedResults.updated_at = new Date().toISOString()
@@ -431,7 +432,8 @@ module.exports = function(expect, request, baseUrl) {
       });
     });
 
-    it("successfully patches a project's uri, slugs, and name by its manager",
+    it("successfully patches a project's uri, slugs, name, and " +
+    'default_activity by its manager',
     function(done) {
       const oldUser = user;
       const oldPass = password;
@@ -456,6 +458,7 @@ module.exports = function(expect, request, baseUrl) {
           expectedResults.name = patchedProject.name;
           expectedResults.uri = patchedProject.uri;
           expectedResults.slugs = patchedProject.slugs;
+          expectedResults.default_activity = patchedProject.default_activity;
           expectedResults.uuid = originalProject.uuid;
           expectedResults.revision = 2;
           expectedResults.updated_at = new Date().toISOString()

--- a/tests/projects.js
+++ b/tests/projects.js
@@ -697,7 +697,6 @@ module.exports = function(expect, request, baseUrl) {
           expectedResults.default_activity = patchedProject.default_activity;
           expectedResults.uuid = originalProject.uuid;
           expectedResults.revision = 2;
-          expectedResults.id = 6;
           expectedResults.updated_at = new Date().toISOString()
                                                  .substring(0, 10);
 
@@ -1042,7 +1041,6 @@ module.exports = function(expect, request, baseUrl) {
       getAPIToken().then(function(token) {
         requestOptions.body = copyJsonObject(postArg);
         requestOptions.body.object = copyJsonObject(originalProject);
-        delete requestOptions.body.object.id;
         delete requestOptions.body.object.uuid;
         delete requestOptions.body.object.revision;
         delete requestOptions.body.object.deleted_at;
@@ -1069,7 +1067,6 @@ module.exports = function(expect, request, baseUrl) {
       getAPIToken().then(function(token) {
         requestOptions.body = copyJsonObject(postArg);
         requestOptions.body.object = copyJsonObject(originalProject);
-        delete requestOptions.body.object.id;
         delete requestOptions.body.object.uuid;
         delete requestOptions.body.object.revision;
         delete requestOptions.body.object.deleted_at;
@@ -1366,9 +1363,8 @@ module.exports = function(expect, request, baseUrl) {
             // the projects/ endpoint should now have one more project
             const expectedGetResults = initialData.concat([
               {
-                owner: 'tschuy',
                 uri: 'https://github.com/osuosl/timesync-node',
-                slugs: ['tsn', 'timesync-node'],
+                slugs: ['timesync-node', 'tsn'],
                 name: 'TimeSync Node',
                 default_activity: null,
                 deleted_at: null,
@@ -1531,7 +1527,7 @@ module.exports = function(expect, request, baseUrl) {
           const expectedError = {
             status: 400,
             error: 'Bad object',
-            text: 'The project is missing a slug',
+            text: 'The project is missing a slugs',
           };
 
           expect(body).to.deep.equal(expectedError);
@@ -1633,7 +1629,7 @@ module.exports = function(expect, request, baseUrl) {
         request.post(requestOptions, function(err, res, body) {
           const expectedError = {
             status: 400,
-            error: 'Bad Object',
+            error: 'Bad object',
             text: 'Field default_activity of project should be string but ' +
                   'was sent as array',
           };
@@ -1737,12 +1733,9 @@ module.exports = function(expect, request, baseUrl) {
           request.get(baseUrl + 'projects?token=' + token,
           function(getErr, getRes, getBody) {
             const jsonGetBody = JSON.parse(getBody);
-            const expectedGetResult = initialData.filter(function(project) {
-              return project.deleted_at === null;
-            });
 
             expect(getRes.statusCode).to.equal(200);
-            expect(jsonGetBody).to.deep.have.same.members(expectedGetResult);
+            expect(jsonGetBody).to.deep.have.same.members(initialData);
 
             done();
           });
@@ -1818,6 +1811,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://code.osuosl.org/projects/ganeti-webmgr',
       name: 'GANETI WEB MANAGER',
       uuid: 'c285963e-192b-4e99-9d92-a940519f1fbd',
+      default_activity: null,
       revision: 2,
       deleted_at: null,
       updated_at: currentTime,
@@ -1835,6 +1829,7 @@ module.exports = function(expect, request, baseUrl) {
       uri: 'https://code.osuosl.org/projects/ganeti-webmgr',
       name: 'GANETI WEB MANAGER',
       uuid: 'c285963e-192b-4e99-9d92-a940519f1fbd',
+      default_activity: null,
       revision: 2,
       deleted_at: null,
       updated_at: currentTime,
@@ -1851,6 +1846,7 @@ module.exports = function(expect, request, baseUrl) {
           uri: 'https://code.osuosl.org/projects/ganeti-webmgr',
           name: 'Ganeti Web Manager',
           uuid: 'c285963e-192b-4e99-9d92-a940519f1fbd',
+          default_activity: null,
           revision: 1,
           deleted_at: null,
           updated_at: null,

--- a/tests/times.js
+++ b/tests/times.js
@@ -3073,7 +3073,7 @@ module.exports = function(expect, request, baseUrl) {
       });
     });
 
-    it('creates a new time with activities', function(done) {
+    it('creates a new time with default activity', function(done) {
       getAPIToken().then(function(token) {
         const time = {
           duration: 20,

--- a/tests/times.js
+++ b/tests/times.js
@@ -3073,6 +3073,63 @@ module.exports = function(expect, request, baseUrl) {
       });
     });
 
+    it('creates a new time with activities', function(done) {
+      getAPIToken().then(function(token) {
+        const time = {
+          duration: 20,
+          user: 'tschuy',
+          project: 'ts',
+          notes: '',
+          issue_uri: 'https://github.com/osuosl/gwm/issues/1',
+          date_worked: '2015-07-30',
+        };
+
+        const postArg = getPostObject(baseUrl + 'times/', time);
+
+        postArg.body.auth.token = token;
+
+        request.post(postArg, function(postErr, postRes, postBody) {
+          expect(postErr).to.equal(null);
+          expect(postRes.statusCode).to.equal(200);
+
+          time.uuid = postBody.uuid;
+          time.revision = 1;
+
+          expect(postBody).to.deep.equal(time);
+
+          const createdAt = new Date().toISOString().substring(0, 10);
+          request.get(baseUrl + 'times?token=' + token,
+          function(getErr, getRes, getBody) {
+            const expectedResults = initialData.concat([
+              {
+                duration: 20,
+                user: 'tschuy',
+                project: ['ts', 'timesync'].sort(),
+                activities: ['dev'],
+                notes: '',
+                issue_uri: 'https://github.com/osuosl/gwm/issues/1',
+                date_worked: '2015-07-30',
+                created_at: createdAt,
+                updated_at: null,
+                deleted_at: null,
+                uuid: time.uuid,
+                revision: 1,
+              },
+            ]);
+
+            const jsonGetBody = JSON.parse(getBody);
+            expectedResults[expectedResults.length - 1].activities.sort();
+            jsonGetBody[jsonGetBody.length - 1].activities.sort();
+
+            expect(getErr).to.be.a('null');
+            expect(getRes.statusCode).to.equal(200);
+            expect(jsonGetBody).to.deep.have.same.members(expectedResults);
+            done();
+          });
+        });
+      });
+    });
+
     it('fails with a bad token', function(done) {
       const time = {
         duration: 20,


### PR DESCRIPTION
Projects have an optional ``default_activity`` field. When a time is posted with a project with a default activity but no activities, it is given the default activity. If the time is posted with a project with no default activity and no activities, an error is returned. If the time is posted with activities, the project's default activity is ignored. If the project's default activity is changed, it has no impact at all on the time (even if the time was created with the default activity). Fixes #106.