### PR TITLE
Fix "cannot set headers after they are set" error by cleaning up transactions.

### DIFF
--- a/src/activities.js
+++ b/src/activities.js
@@ -119,23 +119,11 @@ module.exports = function(app) {
           // delete activity after running through the checks
           trx('activities').where('slug', req.params.slug)
           .update({'deleted_at': Date.now(), 'slug': null})
-          .then(function(numObj) {
-            /* When deleting something from the table, the number of
-            objects deleted is returned. So to confirm that deletion was
-            successful, make sure that the number returned is at least
-            one. */
-            if (numObj >= 1) {
-              trx.commit();
-              return res.send();
-            }
-
+          .then(function() {
+            trx.commit();
+            return res.send();
+          }).catch(function() {
             trx.rollback();
-            const err = errors.errorObjectNotFound('slug', req.params.slug);
-            return res.status(err.status).send(err);
-          }).catch(function(error) {
-            trx.rollback();
-            const err = errors.errorServerError(error);
-            return res.status(err.status).send(err);
           });
         }).catch(function(error) {
           const err = errors.errorServerError(error);

--- a/src/projects.js
+++ b/src/projects.js
@@ -296,21 +296,15 @@ module.exports = function(app) {
               .toISOString().substring(0, 10);
 
               trx.commit();
-              res.send(JSON.stringify(obj));
-            }).catch(function(error) {
+              return res.send(JSON.stringify(obj));
+            }).catch(function() {
               trx.rollback();
-              const err = errors.errorServerError(error);
-              return res.status(err.status).send(err);
             });
-          }).catch(function(error) {
+          }).catch(function() {
             trx.rollback();
-            const err = errors.errorServerError(error);
-            return res.status(err.status).send(err);
           });
-        }).catch(function(error) {
+        }).catch(function() {
           trx.rollback();
-          const err = errors.errorServerError(error);
-          return res.status(err.status).send(err);
         });
       }).catch(function(error) {
         const err = errors.errorServerError(error);
@@ -483,10 +477,8 @@ module.exports = function(app) {
 
                       trx.commit();
                       res.send(JSON.stringify(project));
-                    }).catch(function(error) {
+                    }).catch(function() {
                       trx.rollback();
-                      const err = errors.errorServerError(error);
-                      return res.status(err.status).send(err);
                     });
                   } else {
                     trx('projectslugs').update({project: project.id})
@@ -494,26 +486,18 @@ module.exports = function(app) {
                       project.slugs = existingSlugs;
                       trx.commit();
                       res.send(project);
-                    }).catch(function(error) {
+                    }).catch(function() {
                       trx.rollback();
-                      const err = errors.errorServerError(error);
-                      return res.status(err.status).send(err);
                     });
                   }
-                }).catch(function(error) {
+                }).catch(function() {
                   trx.rollback();
-                  const err = errors.errorServerError(error);
-                  return res.status(err.status).send(err);
                 });
-              }).catch(function(error) {
+              }).catch(function() {
                 trx.rollback();
-                const err = errors.errorServerError(error);
-                return res.status(err.status).send(err);
               });
-            }).catch(function(error) {
+            }).catch(function() {
               trx.rollback();
-              const err = errors.errorServerError(error);
-              return res.status(err.status).send(err);
             });
           }).catch(function(error) {
             const err = errors.errorServerError(error);
@@ -584,8 +568,6 @@ module.exports = function(app) {
             least one. */
             if (numObj !== 1) {
               trx.rollback();
-              const err = errors.errorObjectNotFound('slug', req.params.slug);
-              return res.status(err.status).send(err);
             }
 
             trx('projectslugs').where('project', project.id).del()
@@ -594,20 +576,14 @@ module.exports = function(app) {
               .then(function() {
                 trx.commit();
                 return res.send();
-              }).catch(function(error) {
+              }).catch(function() {
                 trx.rollback();
-                const err = errors.errorServerError(error);
-                return res.status(err.status).send(err);
               });
-            }).catch(function(error) {
+            }).catch(function() {
               trx.rollback();
-              const err = errors.errorServerError(error);
-              return res.status(err.status).send(err);
             });
-          }).catch(function(error) {
+          }).catch(function() {
             trx.rollback();
-            const err = errors.errorServerError(error);
-            return res.status(err.status).send(err);
           });
         }).catch(function(error) {
           const err = errors.errorServerError(error);


### PR DESCRIPTION
Calling rollback() on a transaction causes the catch function on ``knex.transaction()`` to always be called. By removing the server error blocks from the inner catch blocks, such that these only contain calls to rollback(), we can prevent the "cannot set headers after they are set" error that occurs due to attempting to send an error twice.