### PR TITLE
Fix small bugs introduced when merging branches earlier.

### DIFF
--- a/docs/source/design/libraries.rst
+++ b/docs/source/design/libraries.rst
@@ -41,27 +41,27 @@ Knex uses Bluebird promises. For information on promises in general, see the
 `MDN documentation`_ on promises. For how to use Bluebird promises specifically,
 see `Bluebird's README`_.
 
-A very important thing to note is knex's `connection pooling`_. Connections to databases
-such as PostgreSQL and MySQL default to a minimum of two pooled connections and a maximum
-of eight. This is certainly sufficient for production at this time, but it may become
-necessary in the future to increase this in order to scale the application.
+.. important::
 
-SQLite, however, is only allowed one connection when using a file, due to
-file access issues; when using an in-memory database, on the other hand, it is allowed
-near-unlimited connections. This means that when running the application locally, which is
-done in a SQLite database, using the root knex object inside of a transaction WILL result
-in deadlock and thus in the application hanging (see `this example of it failing`_;
-`this PR`_ may fix the issue when it is merged, causing overuse of connections to instead
-return an error).
+    Knex maintains `connection pools`_ to its databases; databases such as PostgreSQL and
+    MySQL default to a **minimum of two** pooled connections and a maximum of eight.
+    SQLite, however, is only allowed **one connection** when using a file, due to file
+    access issues; when using an in-memory database, on the other hand, it is allowed
+    near-unlimited connections.
 
-The fact that testing occurs on an in memory database means that this issue is subverted
-in tests. This unfortunately means that automatically testing for these conditions is not
+When running the application locally, which is done in a SQLite database, using the root
+knex object inside of a transaction WILL result in deadlock and thus in the application
+hanging (see `this example of it failing`_; `this PR`_ may fix the issue when it is
+merged, causing overuse of connections to instead return an error).
+
+Because testing occurs on an in memory database, this issue is subverted in tests.
+This unfortunately means that automatically testing for these conditions is not
 currently possible.
 
 .. _Knex documentation: http://knexjs.org/
 .. _MDN documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 .. _Bluebird's README: https://github.com/petkaantonov/bluebird#introduction
-.. _connection pooling: http://knexjs.org/#Installation-pooling
+.. _connection pools: http://knexjs.org/#Installation-pooling
 .. _this example of it failing: https://github.com/tgriesser/knex/issues/1171
 .. _this PR: https://github.com/tgriesser/knex/pull/1177
 

--- a/docs/source/design/libraries.rst
+++ b/docs/source/design/libraries.rst
@@ -41,9 +41,29 @@ Knex uses Bluebird promises. For information on promises in general, see the
 `MDN documentation`_ on promises. For how to use Bluebird promises specifically,
 see `Bluebird's README`_.
 
+A very important thing to note is knex's `connection pooling`_. Connections to databases
+such as PostgreSQL and MySQL default to a minimum of two pooled connections and a maximum
+of eight. This is certainly sufficient for production at this time, but it may become
+necessary in the future to increase this in order to scale the application.
+
+SQLite, however, is only allowed one connection when using a file, due to
+file access issues; when using an in-memory database, on the other hand, it is allowed
+near-unlimited connections. This means that when running the application locally, which is
+done in a SQLite database, using the root knex object inside of a transaction WILL result
+in deadlock and thus in the application hanging (see `this example of it failing`_;
+`this PR`_ may fix the issue when it is merged, causing overuse of connections to instead
+return an error).
+
+The fact that testing occurs on an in memory database means that this issue is subverted
+in tests. This unfortunately means that automatically testing for these conditions is not
+currently possible.
+
 .. _Knex documentation: http://knexjs.org/
 .. _MDN documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 .. _Bluebird's README: https://github.com/petkaantonov/bluebird#introduction
+.. _connection pooling: http://knexjs.org/#Installation-pooling
+.. _this example of it failing: https://github.com/tgriesser/knex/issues/1171
+.. _this PR: https://github.com/tgriesser/knex/pull/1177
 
 Mocha and Chai
 --------------

--- a/src/activities.js
+++ b/src/activities.js
@@ -245,7 +245,7 @@ module.exports = function(app) {
     knex.transaction(function(trx) {
       trx('activities').first().where({slug: req.params.slug})
       .update({newest: false}).then(function() {
-        knex('activities').first().select(
+        trx('activities').first().select(
           'activities.name as name',
           'activities.slug as slug',
           'activities.uuid as uuid',
@@ -279,6 +279,7 @@ module.exports = function(app) {
             activity.updated_at = new Date(activity.updated_at)
             .toISOString().substring(0, 10);
 
+            trx.commit();
             return res.send(activity);
           }).catch(function() {
             trx.rollback();

--- a/src/times.js
+++ b/src/times.js
@@ -823,7 +823,7 @@ module.exports = function(app) {
                   const timeID = id[0];
 
                   if (!obj.activities) {
-                    knex('timesactivities').select('activity')
+                    trx('timesactivities').select('activity')
                     .where('time', oldId).then(function(activities) {
                       const taInsertion = [];
                       /* eslint-disable prefer-const */


### PR DESCRIPTION
As a result of rebasing #206, two small bugs were introduced. 1) A function which used transactions did not call ``commit()`` at the end, which would have prevented the database from being updated. 2) Two functions use the root knex object inside of a transaction for a select call, which one might think appears to be legal, but in fact will cause the application to hang indefinitely. This fixes those bugs.