### PR TITLE
Fixed ordering of parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you have a user instance already, then simply first authenticate (angle
 brackets indicate user input):
 
 ```
-$ curl -XPOST -d '{"auth":{"type":"password","<username>":"user","password":"<pass>"}}' -H "Content-Type: application/json" http://localhost:8000/v1/login
+$ curl -XPOST -d '{"auth":{"type":"password","username":"<user>","password":"<pass>"}}' -H "Content-Type: application/json" http://localhost:8000/v1/login
 ```
 
 This will print out a long JWT token, which you can then place into the data on


### PR DESCRIPTION
When I use the snippet mentioned in the README for generating a web token (assuming my username is `ichait` and password is `pass`) - 

```
$ curl -X POST -d '{"auth":{"type":"password","ichait":"username","password":"pass"}}' -H "Content-Type: application/json" http://localhost:8000/v1/login
```

I get the following error - 

```
{"status":401,"error":"Authentication failure","text":"Missing credentials"}%
```


And when I use the following snippet it works fine -

```
$ curl -X POST -d '{"auth":{"type":"password","username":"ichait","password":"pass"}}' -H "Content-Type: application/json" http://localhost:8000/v1/login
```

Generates a web token - 

```
{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJITUFDLVNIQTUxMiJ9.eyJpc3MiOiJ0aW1lc3luYy1sb2NhbCIsInN1YiI6ImljaGFpdCIsImV4cCI6MTQ1NzU3NTg2NzkxOCwiaWF0IjoxNDU3NTc0MDY3OTE4fQ==.0ygg5yx1wHLa6t1dU2BnN21IgiK3dP/Exv2nmTpo5I5RlWR7y3vPNiliikBwakiBZt3KivBrGJBqSkNY+UAWig=="}%
```

I guess the current ordering for supplying user input is incorrect. Or am I missing something?