### PR TITLE
Added a postgres docker testing container command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ $ curl -XGET -s localhost:8000/v1/times?token=<token> | python -m json.tool
 
 Your output should look something like the above.
 
+If you would like to test the Postgres database, but don't want to setup a
+whole Postgres database, the command ``npm run test_pg_docker`` will spin up a
+docker container and run the tests.
+
+The postgres container will continue to run until you manually kill it
+(``docker rm -f postgres_pg``) or when you run the tests again.
+
+If you want to run the ``test_pg_docker`` command make sure of the following:
+
+* You have docker installed and the daemon is running.
+* You are in the docker group or are able to run docker as a non super-user.
+
 Database Backends
 -----------------
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "linter": "jshint ./src ./tests ./scripts && eslint ./src ./tests ./scripts",
     "fixtures": "node --harmony ./scripts/load_fixtures.js",
     "test": "TEST=true CONSOLE=true INSTANCE_NAME=timesync SECRET_KEY=secret NODE_ENV=mocha_sqlite TIMESYNC_AUTH_MODULES='[\"ldap\",\"password\"]' TIMESYNC_LDAP_URL=ldap://localhost:1389 TIMESYNC_LDAP_SEARCH_BASE=ou=passport-ldapauth PORT=8851 DEBUG=true mocha --harmony tests",
-    "test_pg": "TEST=true CONSOLE=true INSTANCE_NAME=timesync SECRET_KEY=secret NODE_ENV=mocha knex migrate:latest && NODE_ENV=mocha TIMESYNC_AUTH_MODULES='[\"ldap\",\"password\"]' TIMESYNC_LDAP_URL=ldap://localhost:1389 TIMESYNC_LDAP_SEARCH_BASE=ou=passport-ldapauth PORT=8851 DEBUG=true mocha --harmony tests",
+    "test_pg": "NODE_ENV=mocha knex migrate:latest && TEST=true CONSOLE=true NODE_ENV=mocha INSTANCE_NAME=timesync SECRET_KEY=secret TIMESYNC_AUTH_MODULES='[\"ldap\",\"password\"]' TIMESYNC_LDAP_URL=ldap://localhost:1389 TIMESYNC_LDAP_SEARCH_BASE=ou=passport-ldapauth PORT=8851 DEBUG=true mocha --harmony tests",
+    "test_pg_docker": "export TEST_PG_CONNECTION_STRING=\"postgres://timesync:timesync@localhost:5432/timesync\" && sh ./scripts/pg_docker.sh && NODE_ENV=mocha knex migrate:latest && TEST=true CONSOLE=true NODE_ENV=mocha INSTANCE_NAME=timesync SECRET_KEY=secret TIMESYNC_AUTH_MODULES='[\"ldap\",\"password\"]' TIMESYNC_LDAP_URL=ldap://localhost:1389 TIMESYNC_LDAP_SEARCH_BASE=ou=passport-ldapauth PORT=8851 DEBUG=true mocha --harmony tests",
     "latte": "sh ./scripts/latte.sh",
     "coverage": "TEST=true CONSOLE=true INSTANCE_NAME=timesync SECRET_KEY=secret NODE_ENV=mocha_sqlite TIMESYNC_AUTH_MODULES='[\"ldap\",\"password\"]' TIMESYNC_LDAP_URL=ldap://localhost:1389 TIMESYNC_LDAP_SEARCH_BASE=ou=passport-ldapauth PORT=8851 DEBUG=true node --harmony ./node_modules/istanbul/lib/cli.js cover _mocha -- tests",
     "create-account": "node --harmony ./scripts/create-account.js"

--- a/scripts/pg_docker.sh
+++ b/scripts/pg_docker.sh
@@ -1,0 +1,58 @@
+###
+# POSTGRES_PASSWORD:  timesync
+# POSTGRES_USER:      timesync
+# POSTGRES_DB:        timesync
+# POSTGRES_PORT:      5432
+# POSTGRES_CONTAINER: timesync_pg
+###
+
+if [ -z "$POSTGRES_PASSWORD" ]; then
+  echo "Setting POSTGRES_PASSWORD"
+  POSTGRES_PASSWORD='timesync'
+fi
+
+if [ -z "$POSTGRES_USER" ]; then
+  echo "Setting POSTGRES_USER"
+  POSTGRES_USER='timesync'
+fi
+
+if [ -z "$POSTGRES_DB" ]; then
+  echo "Setting POSTGRES_DB"
+  POSTGRES_DB='timesync'
+fi
+
+if [ -z "$POSTGRES_PORT" ]; then
+  echo "Setting POSTGRES_PORT"
+  POSTGRES_PORT=5432
+fi
+
+if [ -z "$POSTGRES_CONTAINER" ]; then
+  echo "Setting POSTGRES_CONTAINER"
+  POSTGRES_CONTAINER='timesync_pg'
+fi
+
+docker version > /dev/null
+
+if [ $? != 0 ]; then
+  echo "Please start the docker service"
+  echo "\`systemctl start docker\`"
+else
+  echo docker rm -f $POSTGRES_CONTAINER
+  docker rm -f $POSTGRES_CONTAINER
+
+  echo docker run --name=$POSTGRES_CONTAINER \
+             -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
+             -e POSTGRES_USER=$POSTGRES_USER \
+             -e POSTGRES_DB=$POSTGRES_DB \
+             -p $POSTGRES_PORT:5432 \
+             -d postgres
+
+  docker run --name=$POSTGRES_CONTAINER \
+             -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
+             -e POSTGRES_USER=$POSTGRES_USER \
+             -e POSTGRES_DB=$POSTGRES_DB \
+             -p $POSTGRES_PORT:5432 \
+             -d postgres
+  echo "Starting Postgres Database Container"
+  sleep 10
+fi


### PR DESCRIPTION
So we had a bit of difficulty with the /users endpoint and postgres.

To hopefully sidestep this problem later on I added a command:

  `npm run test_pg_docker`

This will automatically spin up a docker container with postgres
installed. It will then spin up a database and run the postgres-backed
tests suite.

Notes:
  - You should be able to run docker as a non-super-user for this to run
    correctly. (add yourself to the docker group)
  - The docker daemon has to be running.
  - The script has a built in 10 second waiting period between spinning
    up the container and moving on. This is so postgres has ample time
    to create your database. If you get errors related to your table not
    being created you'll probably want to bump that time up a bit.