### PR TITLE
Fix crashes on receiving bad json.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -38,9 +38,15 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.set('knex', knex);
 app.set('log', log);
 
+const errors = require('./errors');
+
+/*
+ * Catch errors due to malformed or invalid JSON in request bodies and
+ * return a 400 error
+ */
 app.use(function(err, req, res, next) {
   if (err instanceof SyntaxError && err.status === 400) {
-    return res.status(400).send();
+    return errors.send(errors.errorBadObjectInvalidObject(), res);
   }
   next();
 });

--- a/src/app.js
+++ b/src/app.js
@@ -38,6 +38,13 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.set('knex', knex);
 app.set('log', log);
 
+app.use(function(err, req, res, next) {
+  if (err instanceof SyntaxError && err.status === 400) {
+    return res.status(400).send();
+  }
+  next();
+});
+
 // Set API version prefix
 app.set('version', '/v0');
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -104,6 +104,16 @@ module.exports = {
   },
 
   /*
+  * Error 4: Bad object. Variant 4: invalid object. Client POSTed an object
+  * which could not be parsed as valid JSON, and the server is unable to
+  * interpret the object at all.
+  */
+  errorBadObjectInvalidObject: function() {
+    return createError(400, 'Bad object', 'The request body could not be ' +
+    'parsed as valid JSON');
+  },
+
+  /*
   * Error 5: Invalid identifier. The given slug or ID is not of the correct
   * format to be valid, and therefore could never point to a valid object.
   *

--- a/tests/test.js
+++ b/tests/test.js
@@ -62,6 +62,46 @@ const endTransact = function(done) {
   });
 };
 
+describe('Basic', function() {
+  this.timeout(1000);
+  beforeEach(transact);
+  afterEach(endTransact);
+
+  before(function(done) {
+    knex.migrate.latest().then(function() {
+      done();
+    });
+  });
+
+  it('should have a response at base URL', function(done) {
+    request.get(baseUrl, function(err, res, body) {
+      expect(body.toString()).to.equal('Cannot GET /v0/\n');
+      done();
+    });
+  });
+
+  it('should return an error on invalid JSON', function(done) {
+    const requestOptions = {
+      url: baseUrl + 'login',
+      body: '{"auth": {"type": "password", username: "patcht". password: ' +
+      'drowssap}',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+    };
+    request.post(requestOptions, function(err, res, body) {
+      expect(JSON.parse(body)).to.deep.equal({
+        status: 400,
+        error: 'Bad object',
+        text: 'The request body could not be parsed as valid JSON',
+      });
+
+      done();
+    });
+  });
+});
+
 describe('Endpoints', function() {
   this.timeout(1000);
   beforeEach(transact);


### PR DESCRIPTION
Fixes #271.

Adds a middleware that checks for errors, and if there is an error, it returns a 400. Otherwise, it continues as normal.