### PR TITLE
Add protective HTTP headers for increased security.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-airbnb": "^1.0.0",
     "eslint-plugin-react": "^3.8.0",
     "express": "^4.13.4",
+    "helmet": "^2.1.0",
     "knex": "^0.10.0",
     "ldapjs": "^1.0.0",
     "log": "^1.4.0",

--- a/src/app.js
+++ b/src/app.js
@@ -30,9 +30,21 @@ const Log = require('log');
 const Ain = require('ain2');
 const fs = require('fs');
 
+const helmet = require('helmet');
+
 const log = require('./log')(Log, Ain, fs);
 
 const app = express();
+app.use(helmet()); // Set a variety of HTTP headers to improve security
+app.use(helmet.noCache()); // Disallow all caching; not set by default
+app.use(helmet.contentSecurityPolicy({ // Set a CSP; not set by default
+  directives: {
+    defaultSrc: ['none'], // Disallow any data to come from the TS server
+    scriptSrc: ['self'], // Except scripts and AJAX requests
+    connectSrc: ['self'], // To prevent MITM and XSS attacks
+    // reportUri: '/', // Consider adding in the future
+  },
+}));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.set('knex', knex);


### PR DESCRIPTION
This was going to be part of a larger audit (following [Express's security guidelines](http://expressjs.com/en/advanced/best-practice-security.html)), but it looks like we've already done a pretty good job at preventing a lot of threats. Introducing [helmet](https://www.npmjs.com/package/helmet) was the only significant thing I could add.