### PR TITLE
Add CORS header support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-eslint": "^4.1.5",
     "bcrypt": "^0.8.5",
     "body-parser": "^1.15.0",
+    "cors": "^2.7.1",
     "eslint": "^1.9.0",
     "eslint-config-airbnb": "^1.0.0",
     "eslint-plugin-react": "^3.8.0",

--- a/src/app.js
+++ b/src/app.js
@@ -38,6 +38,8 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.set('knex', knex);
 app.set('log', log);
 
+app.use(require('cors')());
+
 const errors = require('./errors');
 
 /*


### PR DESCRIPTION
Fixes #272. 

Turns out express provides a middleware for this to make it easy.