### PR TITLE
Remove template strings to prevent crashes in old versions of Node.js.

### DIFF
--- a/src/activities.js
+++ b/src/activities.js
@@ -277,7 +277,7 @@ module.exports = function(app) {
 
     if (currObj.slug && !helpers.validateSlug(currObj.slug)) {
       return errors.send(errors.errorBadObjectInvalidField('activity', 'slug',
-                          'valid slug', `invalid slug ${currObj.slug}`), res);
+                          'valid slug', 'invalid slug ' + currObj.slug), res);
     }
 
     knex('activities').where('slug', currObj.slug)


### PR DESCRIPTION
## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Remove template strings
- [X] Prevent crashes in Node 0.12

@osuosl/devs