### PR TITLE
Make create endpoints return *_at field and project update return users

### DIFF
--- a/src/activities.js
+++ b/src/activities.js
@@ -445,6 +445,8 @@ module.exports = function(app) {
           // newly created activity
           obj.created_at = new Date(obj.created_at)
           .toISOString().substring(0, 10);
+          obj.updated_at = null;
+          obj.deleted_at = null;
 
           return res.send(JSON.stringify(obj));
         }).catch(function(error) {

--- a/src/projects.js
+++ b/src/projects.js
@@ -765,6 +765,7 @@ module.exports = function(app) {
               project.revision += 1;
               project.created_at = parseInt(project.created_at, 10);
               project.updated_at = Date.now();
+              project.deleted_at = null;
               project.newest = true;
 
               const oldId = project.id;
@@ -890,53 +891,83 @@ module.exports = function(app) {
                             return slug.name;
                           });
 
-                          if (helpers.getType(obj.slugs) === 'array') {
-                            const newSlugs = [];
-
-                            trx('projectslugs').del().where({project: oldId})
-                            .then(function() {
-                              /* eslint-disable */
-                              for (let slug of obj.slugs) {
-                              /* eslint-enable */
-                                newSlugs.push(trx('projectslugs')
-                                .insert({project: projID, name: slug}));
+                          knex('userroles').select(
+                            'users.username as user',
+                            'userroles.project as project',
+                            'userroles.member as member',
+                            'userroles.spectator as spectator',
+                            'userroles.manager as manager')
+                          .innerJoin('users', 'users.id', 'userroles.user')
+                          .where('userroles.project', projID)
+                          .then(function(projRoles) {
+                            if (projRoles && projRoles.length > 0) {
+                              project.users = {};
+                              /* eslint-disable prefer-const */
+                              for (let role of projRoles) {
+                                /* eslint-enable prefer-const */
+                                project.users[role.user] = {
+                                  // Use !! because they may be numbers
+                                  // !! operator forces to boolean type
+                                  member: !!role.member,
+                                  spectator: !!role.spectator,
+                                  manager: !!role.manager,
+                                };
                               }
+                            }
 
-                              Promise.all(newSlugs).then(function() {
-                                project.slugs = obj.slugs.sort();
-                                delete project.newest;
-                                trx.commit();
-                                res.send(JSON.stringify(project));
+                            if (helpers.getType(obj.slugs) === 'array') {
+                              const newSlugs = [];
+
+                              trx('projectslugs').del().where({project: oldId})
+                              .then(function() {
+                                /* eslint-disable */
+                                for (let slug of obj.slugs) {
+                                  /* eslint-enable */
+                                  newSlugs.push(trx('projectslugs')
+                                    .insert({project: projID, name: slug}));
+                                }
+
+                                Promise.all(newSlugs).then(function() {
+                                  project.slugs = obj.slugs.sort();
+                                  delete project.newest;
+                                  trx.commit();
+                                  res.send(JSON.stringify(project));
+                                }).catch(function(error) {
+                                  log.error(req, 'Error inserting slugs: ' +
+                                    error);
+                                  trx.rollback();
+                                });
                               }).catch(function(error) {
-                                log.error(req, 'Error inserting slugs: ' +
-                                          error);
+                                log.error(req, 'Error deleting old slugs: ' +
+                                  error);
                                 trx.rollback();
                               });
-                            }).catch(function(error) {
-                              log.error(req, 'Error deleting old slugs: ' +
-                                        error);
-                              trx.rollback();
-                            });
-                          } else {
-                            trx('projectslugs').update({project: projID})
-                            .where({project: oldId}).then(function() {
-                              project.slugs = existingSlugs.sort();
-                              delete project.newest;
-                              trx.commit();
-                              res.send(project);
-                            }).catch(function(error) {
-                              log.error(req, 'Error updating slugs: ' + error);
-                              trx.rollback();
-                            });
-                          }
+                            } else {
+                              trx('projectslugs').update({project: projID})
+                              .where({project: oldId}).then(function() {
+                                project.slugs = existingSlugs.sort();
+                                delete project.newest;
+                                trx.commit();
+                                res.send(project);
+                              }).catch(function(error) {
+                                log.error(req, 'Error updating slugs: ' +
+                                  error);
+                                trx.rollback();
+                              });
+                            }
+                          }).error(function(error) {
+                            log.error(req, 'Error retrieving old roles: ' +
+                              error);
+                            trx.rollback();
+                          });
                         }).catch(function(error) {
                           log.error(req, 'Error retrieving existing slugs: ' +
-                                                                        error);
+                            error);
                           trx.rollback();
                         });
                       }).catch(function(error) {
                         log.error(req, 'Error transferring user roles: ' +
-                                                                        error);
+                          error);
                         trx.rollback();
                       });
                     }

--- a/src/projects.js
+++ b/src/projects.js
@@ -545,6 +545,8 @@ module.exports = function(app) {
                       trx('userroles').insert(roles).then(function() {
                         obj.created_at = new Date(obj.created_at)
                         .toISOString().substring(0, 10);
+                        obj.updated_at = null;
+                        obj.deleted_at = null;
 
                         /* eslint-disable prefer-const */
                         /* eslint-disable guard-for-in */
@@ -579,6 +581,8 @@ module.exports = function(app) {
                   } else {
                     obj.created_at = new Date(obj.created_at)
                     .toISOString().substring(0, 10);
+                    obj.updated_at = null;
+                    obj.deleted_at = null;
 
                     trx.commit();
                     return res.send(JSON.stringify(obj));
@@ -830,6 +834,7 @@ module.exports = function(app) {
                                   Promise.all(newSlugs).then(function() {
                                     project.slugs = obj.slugs.sort();
                                     delete project.newest;
+                                    project.users = obj.users;
                                     trx.commit();
                                     res.send(JSON.stringify(project));
                                   }).catch(function(error) {
@@ -847,6 +852,7 @@ module.exports = function(app) {
                                 .where({project: oldId}).then(function() {
                                   project.slugs = existingSlugs.sort();
                                   delete project.newest;
+                                  project.users = obj.users;
                                   trx.commit();
                                   res.send(project);
                                 }).catch(function(error) {

--- a/src/projects.js
+++ b/src/projects.js
@@ -891,7 +891,7 @@ module.exports = function(app) {
                             return slug.name;
                           });
 
-                          knex('userroles').select(
+                          trx('userroles').select(
                             'users.username as user',
                             'userroles.project as project',
                             'userroles.member as member',

--- a/src/times.js
+++ b/src/times.js
@@ -639,7 +639,8 @@ module.exports = function(app) {
 
                     trx('timesactivities').insert(taInsertion).then(function() {
                       trx.commit();
-                      time.created_at = new Date().toISOString().substring(0, 10);
+                      time.created_at = new Date().toISOString()
+                        .substring(0, 10);
                       time.updated_at = null;
                       time.deleted_at = null;
                       return res.send(JSON.stringify(time));

--- a/src/times.js
+++ b/src/times.js
@@ -639,6 +639,9 @@ module.exports = function(app) {
 
                     trx('timesactivities').insert(taInsertion).then(function() {
                       trx.commit();
+                      time.created_at = new Date().toISOString().substring(0, 10);
+                      time.updated_at = null;
+                      time.deleted_at = null;
                       return res.send(JSON.stringify(time));
                     }).catch(function(error) {
                       log.error(req, 'Error creating activity references for ' +

--- a/tests/activities.js
+++ b/tests/activities.js
@@ -448,6 +448,8 @@ module.exports = function(expect, request, baseUrl) {
       slug: 'chef',
       name: 'Chef',
       created_at: new Date().toISOString().substring(0, 10),
+      updated_at: null,
+      deleted_at: null,
       revision: 1,
     };
 

--- a/tests/projects.js
+++ b/tests/projects.js
@@ -320,6 +320,8 @@ module.exports = function(expect, request, baseUrl) {
       default_activity: 'meeting',
       revision: 1,
       created_at: new Date().toISOString().substring(0, 10),
+      updated_at: null,
+      deleted_at: null,
       users: {
         Site_Manager: {member: true, spectator: true, manager: true},
         user1: {member: true, spectator: true, manager: false},

--- a/tests/projects.js
+++ b/tests/projects.js
@@ -963,7 +963,7 @@ module.exports = function(expect, request, baseUrl) {
 
           if (postBodies !== undefined) {
             // Is the recieved body within the array of expected bodies
-            expect(postBodies).to.include(body);
+            expect(postBodies).to.deep.include(body);
           }
 
           // Always checks for valid get request

--- a/tests/projects.js
+++ b/tests/projects.js
@@ -992,7 +992,7 @@ module.exports = function(expect, request, baseUrl) {
       const statusCode = 200;
 
       checkPostToEndpoint(done, null, postObj, expectedResults, error,
-                 statusCode);
+                 statusCode, [expectedResults]);
     });
 
     it("successfully patches a project's uri, slugs, name, and " +
@@ -1003,7 +1003,7 @@ module.exports = function(expect, request, baseUrl) {
       const statusCode = 200;
 
       checkPostToEndpoint(done, null, postObj, expectedResults, error,
-                 statusCode, undefined, 'Site_Manager', 'drowssap');
+                 statusCode, [expectedResults], 'Site_Manager', 'drowssap');
     });
 
     it("successfully patches a project's uri, slugs, name, and " +
@@ -1015,7 +1015,7 @@ module.exports = function(expect, request, baseUrl) {
       const statusCode = 200;
 
       checkPostToEndpoint(done, null, postObj, expectedResults, error,
-                 statusCode, undefined, 'delProj_Manager', 'wording');
+                 statusCode, [expectedResults], 'delProj_Manager', 'wording');
     });
 
     it("successfully patches a project's uri", function(done) {

--- a/tests/times.js
+++ b/tests/times.js
@@ -2196,6 +2196,9 @@ module.exports = function(expect, request, baseUrl) {
       notes: '',
       issue_uri: 'https://github.com/osuosl/project1/issues/1',
       date_worked: '2015-07-30',
+      created_at: new Date().toISOString().substring(0, 10),
+      updated_at: null,
+      deleted_at: null,
       revision: 1,
     };
 


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
Fixes #315.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [x] Update tests for returning _at fields
- [X] Update tests for returning users on project update
- [x] Return *_at fields from all create endpoints
- [x] Return `users` field from project update endpoint

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. `npm install`
2. `npm run latte`

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

"382 passing (12s)"

@osuosl/devs