### PR TITLE
Remove if branch which was unreachable.

### DIFF
--- a/src/times.js
+++ b/src/times.js
@@ -626,34 +626,28 @@ module.exports = function(app) {
                 .then(function(timeIds) {
                   const timeId = timeIds[0];
 
-                  if (activityIds) {
-                    const taInsertion = [];
-                    /* eslint-disable prefer-const */
-                    for (let activityId of activityIds) {
-                      /* eslint-enable prefer-const */
-                      taInsertion.push({
-                        time: timeId,
-                        activity: activityId,
-                      });
-                    }
-
-                    trx('timesactivities').insert(taInsertion).then(function() {
-                      trx.commit();
-                      time.created_at = new Date().toISOString()
-                        .substring(0, 10);
-                      time.updated_at = null;
-                      time.deleted_at = null;
-                      return res.send(JSON.stringify(time));
-                    }).catch(function(error) {
-                      log.error(req, 'Error creating activity references for ' +
-                                                              'time: ' + error);
-                      trx.rollback();
+                  const taInsertion = [];
+                  /* eslint-disable prefer-const */
+                  for (let activityId of activityIds) {
+                    /* eslint-enable prefer-const */
+                    taInsertion.push({
+                      time: timeId,
+                      activity: activityId,
                     });
-                  } else {
-                    trx.commit();
-                    time.activities = time.activities.sort();
-                    return res.send(JSON.stringify(time));
                   }
+
+                  trx('timesactivities').insert(taInsertion).then(function() {
+                    trx.commit();
+                    time.created_at = new Date().toISOString()
+                      .substring(0, 10);
+                    time.updated_at = null;
+                    time.deleted_at = null;
+                    return res.send(JSON.stringify(time));
+                  }).catch(function(error) {
+                    log.error(req, 'Error creating activity references for ' +
+                                                            'time: ' + error);
+                    trx.rollback();
+                  });
                 }).catch(function(error) {
                   log.error(req, 'Error inserting updated time entry: ' +
                                                                         error);

--- a/tests/test.js
+++ b/tests/test.js
@@ -75,7 +75,7 @@ describe('Basic', function() {
 
   it('should have a response at base URL', function(done) {
     request.get(baseUrl, function(err, res, body) {
-      expect(body.toString()).to.equal('Cannot GET /v0/\n');
+      expect(body.toString()).to.include('Cannot GET /v0/');
       done();
     });
   });


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
I noticed this while I was working on a different issue. If you look at lines 666-688, it becomes clear that the array passed to `insert()` will always be truthy (note that an empty array is truthy).

Either the user passed in an `activities` array (in which case `time.activities` will be truthy, and the first branch will be taken), and the array passed to `insert()` is the result of calling `helpers.checkActivities()` on the `activities` array, which will only resolve with an array itself.

Or the user didn't pass in an `activities` array (in which case it will be `undefined`, and the second branch is taken), and the app retrieves the `default_activity` from the project (returning an error if it's null), and passes its ID to `insert()`.

In either case `activityIds` will always be truthy, so the if-statement is useless.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Remove a branch which can never be taken.
- [X] Fix test failure caused by new versions of Express.

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. `npm run latte`

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

No output from linters.

`382 passing`

@osuosl/devs